### PR TITLE
i18n fixes

### DIFF
--- a/doc/website/signatures_to_html.py
+++ b/doc/website/signatures_to_html.py
@@ -396,7 +396,7 @@ for f in sorted(kernel) + sorted(methods):
         arg_tbls.append((r, t))
 
 module_tbl = Table(Row("module", "status"))
-for m in ["fs", "keyval", "pkgconfig", "sourceset"]:
+for m in ["fs", "keyval", "pkgconfig", "sourceset", "i18n"]:
     module_tbl += Row(m, positive("supported"))
 
 for m in ["python3", "python"]:
@@ -407,7 +407,6 @@ for m in [
     "dlang",
     "gnome",
     "hotdoc",
-    "i18n",
     "java",
     "modtest",
     "qt",

--- a/src/functions/kernel/dependency.c
+++ b/src/functions/kernel/dependency.c
@@ -389,14 +389,6 @@ handle_special_dependency(struct workspace *wk, struct dep_lookup_ctx *ctx, bool
 			make_obj(wk, &dep->dep.link_args, obj_array);
 			obj_array_foreach(wk, ctx->modules, ctx, handle_appleframeworks_modules_iter);
 		}
-	} else if (strcmp(get_cstr(wk, ctx->name), "intl") == 0) {
-		*handled = true;
-		make_obj(wk, ctx->res, obj_dependency);
-		struct obj_dependency *dep = get_obj_dependency(wk, *ctx->res);
-		dep->name = make_str(wk, "intl");
-		dep->flags |= dep_flag_found;
-		dep->type = dependency_type_external_library;
-
 	} else if (strcmp(get_cstr(wk, ctx->name), "") == 0) {
 		*handled = true;
 		if (ctx->requirement == requirement_required) {


### PR DESCRIPTION
Noticed a few things regarding the i18n support that was merged earlier in the year:

1. The special casing of `intl` in `kernel/dependency.c` is not needed due to the the existing script-based handling of `intl`.
2. I forgot to update the documentation to mark the module as supported by muon.

