### PR TITLE
compilers.c: Fix detection of msvc

### DIFF
--- a/src/compilers.c
+++ b/src/compilers.c
@@ -255,7 +255,7 @@ compiler_detect_c_or_cpp(struct workspace *wk, obj cmd_arr, obj comp_id)
 		}
 	} else if (strstr(cmd_ctx.out.buf, "Free Software Foundation")) {
 		type = compiler_gcc;
-	} else if (strstr(cmd_ctx.out.buf, "Microsoft")) {
+	} else if (strstr(cmd_ctx.out.buf, "Microsoft") || strstr(cmd_ctx.err.buf, "Microsoft")) {
 		type = compiler_msvc;
 	} else {
 		goto detection_over;


### PR DESCRIPTION
For some unknown and perhaps eternally unknowable reason, some versions of msvc print the version number to stderr instead of stdout. So in order to correctly detect these versions of msvc we need to check both stderr and stdout.

This commit add an extra check to do just that. Meson seems to have already encountered this and has [an equivalent fix alongside an understandably exasperated comment](https://github.com/mesonbuild/meson/blob/bb2adc06c0dfde48d1bdccbaa4b3f7782a017f60/mesonbuild/compilers/detect.py#L496-L500).
