### PR TITLE
fix build without git

### DIFF
--- a/tests/project/meson.build
+++ b/tests/project/meson.build
@@ -401,8 +401,9 @@ else
     endif
 endif
 
+meson_tests_dir = meson.current_source_dir() / 'meson-tests'
+
 if git.found()
-    meson_tests_dir = meson.current_source_dir() / 'meson-tests'
     meson_tests_sha = '1e565931348f15f3f9b654f46ab4bf5fa009ca4f'
 
     if not fs.is_dir(meson_tests_dir)


### PR DESCRIPTION
This fixes the build if `git` is not in the build environment.

    muon/tests/project/meson.build:452:34: error undefined object meson_tests_dir
    452 | skip_meson_tests = not fs.is_dir(meson_tests_dir)
                                           ^______________