### PR TITLE
set warning_level to 1 by default

### DIFF
--- a/src/script/per_project_options.meson
+++ b/src/script/per_project_options.meson
@@ -12,7 +12,7 @@ option(
     'warning_level',
     yield: true,
     type: 'combo',
-    value: '3',
+    value: '1',
     choices: ['0', '1', '2', '3', 'everything'],
 )
 option('werror', yield: true, type: 'boolean', value: false)


### PR DESCRIPTION
Implements #95

I agree with this change because it makes projects such as Mesa build out of the box. If this PR is to be rejected for philosphy reasons, such as static linking is better, or code conciseness as a priority for projects using muon, then it would be sensible.

Another thing to note is `default_library`, where its default value in muon is `static`, while in Meson it is `shared`. Shouldn't both be the same?