### PR TITLE
Windows: add 'dll.a' as extension when linking agains shared lib

### DIFF
--- a/include/functions/compiler.h
+++ b/include/functions/compiler.h
@@ -13,7 +13,7 @@ enum find_library_flag {
 	find_library_flag_prefer_static = 1 << 0,
 };
 
-#define COMPILER_DYNAMIC_LIB_EXTS ".so", ".dylib", ".dll"
+#define COMPILER_DYNAMIC_LIB_EXTS ".so", ".dylib", ".dll.a", ".dll"
 #define COMPILER_STATIC_LIB_EXTS ".a", ".lib"
 
 obj find_library(struct workspace *wk, const char *name, obj libdirs, enum find_library_flag flags);


### PR DESCRIPTION
Fixes MSYS2 CI