### PR TITLE
Add fallback to gettimeofday()

### DIFF
--- a/include/platform/timer.h
+++ b/include/platform/timer.h
@@ -19,11 +19,13 @@
 #endif
 
 struct timer {
-#ifdef _WIN32
+#if defined(_WIN32)
 	LARGE_INTEGER freq;
 	LARGE_INTEGER start;
-#else
+#elif defined(CLOCK_MONOTONIC)
 	struct timespec start;
+#else
+	struct timeval start;
 #endif
 };
 

--- a/src/platform/posix/timer.c
+++ b/src/platform/posix/timer.c
@@ -16,14 +16,21 @@
 void
 timer_start(struct timer *t)
 {
+#ifdef CLOCK_MONOTONIC
 	if (clock_gettime(CLOCK_MONOTONIC, &t->start) == -1) {
 		LOG_E("clock_gettime: %s", strerror(errno));
 	}
+#else
+	if (gettimeofday(&t->start, NULL) == -1) {
+		LOG_E("gettimeofday: %s", strerror(errno));
+	}
+#endif
 }
 
 float
 timer_read(struct timer *t)
 {
+#ifdef CLOCK_MONOTONIC
 	struct timespec end;
 
 	if (clock_gettime(CLOCK_MONOTONIC, &end) == -1) {
@@ -34,6 +41,18 @@ timer_read(struct timer *t)
 	double secs = (double)end.tv_sec - (double)t->start.tv_sec;
 	double ns = ((secs * 1000000000.0) + end.tv_nsec) - t->start.tv_nsec;
 	return (float)ns / 1000000000.0f;
+#else
+	struct timeval end;
+
+	if (gettimeofday(&end, NULL) == -1) {
+		LOG_E("gettimeofday: %s", strerror(errno));
+		return 0.0f;
+	}
+
+	double secs = (double)end.tv_sec - (double)t->start.tv_sec;
+	double us = ((secs * 1000000.0) + end.tv_usec) - t->start.tv_usec;
+	return (float)us / 1000000.0f;
+#endif
 }
 
 void


### PR DESCRIPTION
clock_gettime() was only added in macOS 10.12.