### PR TITLE
Switch to upstream glfw3 and apply patches

### DIFF
--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -31,7 +31,6 @@ extern "C" {
 #include "options.h"
 #include "platform/path.h"
 #include "ui.h"
-
 }
 
 bool have_ui = true;
@@ -386,7 +385,8 @@ push_breakpoint(const char *file, uint32_t line, uint32_t col)
 	struct workspace *wk = &ctx->wk;
 
 	breakpoint bp = { .col = col, .line = line };
-	cstr_copy(bp.file, file, sizeof(bp.file));
+	struct str file_str = STRL(file);
+	cstr_copy(bp.file, &file_str);
 	ctx->breakpoints.push_back(bp);
 	vm_dbg_push_breakpoint(wk, make_str(wk, file), line, 0);
 	sync_breakpoints();

--- a/subprojects/glfw3.wrap
+++ b/subprojects/glfw3.wrap
@@ -2,9 +2,10 @@
 ; SPDX-License-Identifier: GPL-3.0-only
 
 [wrap-git]
-url = https://git.sr.ht/~lattis/glfw3
-revision = d70ff6cf248621e88793e18b9bbec400730e68d4
+url = https://github.com/glfw/glfw
+revision = 7b6aead9fb88b3623e3b3725ebb42670cbe4c579
 depth = 1
+patch_directory = glfw3
 
 [provide]
 glfw3 = glfw3_dep

--- a/subprojects/packagefiles/glfw3/meson.build
+++ b/subprojects/packagefiles/glfw3/meson.build
@@ -1,0 +1,36 @@
+project(
+	'glfw',
+	'c',
+	version: '3.3.0',
+	license: 'zlib',
+	default_options: ['default_library=static'],
+)
+
+cc = meson.get_compiler('c')
+compiler_id = cc.get_id()
+
+math_dep = cc.find_library('m', required: false)
+threads_dep = dependency('threads')
+
+if compiler_id == 'msvc'
+	if get_option('glfw_use_msvc_runtime_library_dll')
+		warning('glfw_use_msvc_runtime_library_dll is not implemented')
+		# TODO
+	endif
+endif
+
+host_system = host_machine.system()
+
+backend = get_option('glfw_backend')
+if backend == 'auto'
+	if host_system == 'windows' or host_system == 'cygwin'
+		backend = 'win32'
+	elif host_system == 'darwin'
+		backend = 'cocoa'
+	else
+		error('Unable to determine the backend automatically.')
+	endif
+endif
+
+
+subdir('src')

--- a/subprojects/packagefiles/glfw3/meson_options.txt
+++ b/subprojects/packagefiles/glfw3/meson_options.txt
@@ -1,0 +1,20 @@
+option('glfw_vulkan_static',
+    type: 'boolean',
+    description: 'Use the Vulkan loader statically linked into application',
+    value: false)
+
+option('glfw_use_hybrid_hpg',
+    type: 'boolean',
+    description: 'Force use of high-performance GPU on hybrid systems',
+    value: false)
+
+option('glfw_use_msvc_runtime_library_dll',
+    type: 'boolean',
+    description: 'Use MSVC runtime library DLL',
+    value: true)
+
+option('glfw_backend',
+    type: 'combo',
+    description: 'Backend used for window creation',
+    value: 'auto',
+    choices: ['auto', 'wayland', 'mir', 'osmesa', 'win32', 'cocoa', 'x11'])

--- a/subprojects/packagefiles/glfw3/src/meson.build
+++ b/subprojects/packagefiles/glfw3/src/meson.build
@@ -1,0 +1,197 @@
+# TODO vulkan
+
+sources = [
+    'context.c',
+    'init.c',
+    'input.c',
+    'monitor.c',
+    'vulkan.c',
+    'window.c',
+    'platform.c',
+
+    'null_init.c',
+    'null_joystick.c',
+    'null_monitor.c',
+    'null_window.c',
+]
+
+dependencies = [threads_dep]
+
+if host_system == 'linux' or host_system == 'bsd'
+    dependencies += [math_dep]
+
+    if backend == 'x11'
+        dependencies += [cc.find_library('dl', required: false)]
+    endif
+endif
+
+conf_data = configuration_data()
+foreach b : ['cocoa', 'win32', 'x11', 'wayland', 'osmesa']
+    conf_data.set('_GLFW_' + b.to_upper(), backend == b)
+endforeach
+conf_data.set('_GLFW_BUILD_DLL', get_option('default_library') == 'shared')
+conf_data.set('_GLFW_VULKAN_STATIC', get_option('glfw_vulkan_static'))
+conf_data.set('_GLFW_USE_HYBRID_HPG', get_option('glfw_use_hybrid_hpg'))
+conf_file = configure_file(configuration: conf_data, output: 'glfw_config.h')
+sources += conf_file
+
+if (backend == 'wayland' or backend == 'x11')
+    if host_system == 'linux'
+        sources += ['linux_joystick.c']
+    else
+        sources += ['null_joystick.c']
+    endif
+endif
+
+if backend == 'cocoa'
+    add_languages('objc', native: false)
+
+    dependencies += dependency(
+        'appleframeworks',
+        modules: ['Cocoa', 'IOKit', 'CoreFoundation', 'CoreVideo'],
+    )
+
+    sources += [
+        'cocoa_init.m',
+        'cocoa_joystick.m',
+        'cocoa_monitor.m',
+        'cocoa_time.c',
+        'cocoa_window.m',
+        'egl_context.c',
+        'nsgl_context.m',
+        'osmesa_context.c',
+        'posix_thread.c',
+        'posix_module.c',
+    ]
+elif backend == 'win32'
+    dependencies += cc.find_library('gdi32')
+
+    sources += [
+        'egl_context.c',
+        'osmesa_context.c',
+        'wgl_context.c',
+        'win32_init.c',
+        'win32_joystick.c',
+        'win32_monitor.c',
+        'win32_thread.c',
+        'win32_time.c',
+        'win32_window.c',
+    ]
+elif backend == 'x11'
+    dependencies += dependency('x11')
+    # TODO: XRandR header found?
+    # TODO: Xinerama header found?
+    # TODO: Xkb header found?
+    # TODO: Xcursor header found?
+    sources += [
+        'egl_context.c',
+        'glx_context.c',
+        'osmesa_context.c',
+        'posix_module.c',
+        'posix_poll.c',
+        'posix_thread.c',
+        'posix_time.c',
+        'x11_init.c',
+        'x11_monitor.c',
+        'x11_window.c',
+        'xkb_unicode.c',
+    ]
+elif backend == 'wayland'
+    wayland_client = dependency('wayland-client')
+
+    wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
+    if wayland_scanner_dep.found()
+        wayland_scanner = find_program(
+            wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),
+            native: true,
+        )
+    else
+        wayland_scanner = find_program('wayland-scanner', native: true)
+    endif
+
+    protocols = [
+        'wayland',
+        'xdg-shell',
+        'xdg-decoration-unstable-v1',
+        'viewporter',
+        'relative-pointer-unstable-v1',
+        'pointer-constraints-unstable-v1',
+        'idle-inhibit-unstable-v1',
+        'xdg-activation-v1',
+        'fractional-scale-v1',
+    ]
+
+    wl_protos_src = []
+    wl_protos_headers = []
+
+    foreach name : protocols
+        xml = meson.project_source_root() / 'deps/wayland' / f'@name@.xml'
+        outsrc = f'@name@-client-protocol-code.h'
+        outhdr = f'@name@-client-protocol.h'
+
+        wl_protos_src += custom_target(
+            xml.underscorify() + '_server_c',
+            input: xml,
+            output: outsrc,
+            command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+        )
+
+        wl_protos_headers += custom_target(
+            xml.underscorify() + '_server_h',
+            input: xml,
+            output: outhdr,
+            command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+        )
+    endforeach
+
+    dependencies += [
+        wayland_client,
+        dependency('wayland-egl'),
+        dependency('xkbcommon')
+    ]
+
+    sources += [
+        'egl_context.c',
+        'osmesa_context.c',
+        'posix_thread.c',
+        'posix_time.c',
+        'posix_poll.c',
+        'posix_module.c',
+        'wl_init.c',
+        'wl_monitor.c',
+        'wl_window.c',
+        'xkb_unicode.c',
+        'xkb_unicode.h',
+    ] + wl_protos_src + wl_protos_headers
+elif backend == 'osmesa'
+    dependencies += dependency('osmesa')
+    sources += [
+        'null_init.c',
+        'null_joystick.c',
+        'null_monitor.c',
+        'null_window.c',
+        'osmesa_context.c',
+        'posix_thread.c',
+        'posix_time.c',
+    ]
+endif
+
+include = [include_directories('../include'), include_directories('.')]
+
+glfw3_library = library(
+    'glfw',
+    sources,
+    version: meson.project_version(),
+    c_args: ['-D_GLFW_USE_CONFIG_H'],
+    objc_args: ['-D_GLFW_USE_CONFIG_H'],
+    dependencies: dependencies,
+    include_directories: include,
+)
+
+glfw3_dep = declare_dependency(
+    link_with: [glfw3_library],
+    include_directories: include,
+    dependencies: dependencies,
+)
+
+meson.override_dependency('glfw3', glfw3_dep)


### PR DESCRIPTION
Use Meson/Muon Wrap packagefiles folder to add
meson files to glfw3 and replace custom fork link
with upstream.

While I was there I also fixed some errors with
x11 and wayland linking / headers.

The Meson build files were sourced from the
existing fork.