### PR TITLE
Update meson support to 1.11.2 [wip]

### DIFF
--- a/include/datastructures/stack.h
+++ b/include/datastructures/stack.h
@@ -21,9 +21,13 @@ struct stack {
 void stack_init(struct arena *a, struct stack *stack, uint32_t cap);
 
 void stack_print(struct stack *_stack);
+bool stack_try_push_sized(struct stack *stack, const void *mem, uint32_t size, const char *name);
 void stack_push_sized(struct stack *stack, const void *mem, uint32_t size, const char *name);
 void stack_pop_sized(struct stack *stack, void *mem, uint32_t size);
 void stack_peek_sized(struct stack *stack, void *mem, uint32_t size);
+
+#define stack_try_push(__stack, __it, __nv)                                                           \
+	(stack_try_push_sized((__stack), &(__it), (sizeof(__it)), __FILE__ ":" LINE_STRING " " #__it) ? (__it = __nv, true) : false)
 
 #define stack_push(__stack, __it, __nv)                                                           \
 	stack_push_sized((__stack), &(__it), (sizeof(__it)), __FILE__ ":" LINE_STRING " " #__it); \

--- a/include/functions/external_program.h
+++ b/include/functions/external_program.h
@@ -7,7 +7,15 @@
 #define MUON_FUNCTIONS_EXTERNAL_PROGRAM_H
 #include "lang/func_lookup.h"
 
-void find_program_guess_version(struct workspace *wk, obj cmd_array, obj version_argument, obj *ver);
+enum obj_external_program_cmd_array_flag {
+	obj_external_program_cmd_array_flag_prefer_argv0 = 1 << 0,
+};
+
+obj obj_external_program_cmd_array(struct workspace *wk,
+	struct obj_external_program *ep,
+	enum obj_external_program_cmd_array_flag flags);
+
+void find_program_guess_version(struct workspace *wk, struct obj_external_program *ep, obj version_argument);
 
 FUNC_REGISTER(external_program);
 #endif

--- a/include/lang/compiler.h
+++ b/include/lang/compiler.h
@@ -39,6 +39,7 @@ enum vm_compile_mode {
 	vm_compile_mode_return_after_project = 1 << 5,
 	vm_compile_mode_relaxed_parse = 1 << 6,
 	vm_compile_mode_locals = 1 << 7,
+	vm_compile_mode_tilde_identifier = 1 << 8,
 };
 
 void vm_compile_state_reset(struct workspace *wk);

--- a/include/lang/eval.h
+++ b/include/lang/eval.h
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 
 #include "lang/types.h"
+#include "lang/compiler.h"
 
 struct workspace;
 struct source;
@@ -30,6 +31,7 @@ struct eval_opts {
 	enum build_language lang;
 	enum language_mode lang_mode;
 	enum eval_mode mode;
+	enum vm_compile_mode compile_flags;
 	const struct args_norm *an;
 };
 

--- a/include/lang/lexer.h
+++ b/include/lang/lexer.h
@@ -145,6 +145,7 @@ struct lexer {
 	struct workspace *wk;
 	const struct source *source;
 	const char *src;
+	const char *extra_identifier_chars;
 	struct stack stack;
 	struct lexer_fmt fmt;
 	uint32_t i, ws_start, ws_end;
@@ -153,8 +154,8 @@ struct lexer {
 	uint8_t enclosed_state;
 };
 
-bool is_valid_inside_of_identifier(const char c);
-bool is_valid_start_of_identifier(const char c);
+bool is_valid_inside_of_identifier(const char c, const char* extra);
+bool is_valid_start_of_identifier(const char c, const char* extra);
 bool is_digit(const char c);
 bool is_hex_digit(const char c);
 

--- a/include/lang/object.h
+++ b/include/lang/object.h
@@ -246,6 +246,7 @@ struct build_dep {
 	obj compile_args;
 	obj include_directories;
 	obj link_args;
+	obj link_early_args;
 	obj link_whole;
 	obj link_with;
 	obj link_with_not_found;
@@ -260,6 +261,7 @@ struct build_dep {
 		obj compile_args;
 		obj include_directories;
 		obj link_args;
+		obj link_early_args;
 		obj link_whole;
 		obj link_with;
 		obj link_with_not_found;

--- a/include/lang/object.h
+++ b/include/lang/object.h
@@ -393,10 +393,13 @@ struct obj_dependency {
 };
 
 struct obj_external_program {
-	bool found, guessed_ver;
-	obj cmd_array;
 	obj ver;
-	obj original_argv0;
+	struct {
+		obj cmd_array;
+		obj original_argv0;
+		obj build_target;
+	} impl;
+	bool found;
 };
 
 struct obj_python_installation {

--- a/include/lang/object.h
+++ b/include/lang/object.h
@@ -445,6 +445,7 @@ struct obj_test {
 	obj depends; // obj_array of obj_string
 	obj timeout; // obj_number
 	obj priority; // obj_number
+	obj expected_exitcode; // obj_number
 	bool should_fail, is_parallel, verbose;
 	enum test_category category;
 	enum test_protocol protocol;

--- a/include/lang/typecheck.h
+++ b/include/lang/typecheck.h
@@ -123,7 +123,6 @@ bool typecheck_custom(struct workspace *wk, uint32_t ip, obj obj_id, type_tag ty
 bool typecheck_simple_err(struct workspace *wk, obj o, type_tag type);
 obj typechecking_type_to_str(struct workspace *wk, type_tag t);
 const char *typechecking_type_to_s(struct workspace *wk, type_tag t);
-obj typechecking_type_to_arr(struct workspace *wk, type_tag t);
 type_tag make_complex_type(struct workspace *wk, enum complex_type t, type_tag type, type_tag subtype);
 bool typecheck_typeinfo(struct workspace *wk, obj v, type_tag t);
 

--- a/include/options.h
+++ b/include/options.h
@@ -20,7 +20,7 @@ struct option_override {
 	// strings
 	obj proj, name, val;
 	enum option_value_source source;
-	bool obj_value;
+	bool obj_value, master_project_only;
 };
 
 enum create_option_flag {

--- a/include/options.h
+++ b/include/options.h
@@ -7,7 +7,12 @@
 #define MUON_OPTIONS_H
 #include "lang/workspace.h"
 
-extern bool initializing_builtin_options;
+enum initializing_builtin_options_state {
+	initializing_builtin_options_state_none,
+	initializing_builtin_options_state_global,
+	initializing_builtin_options_state_project,
+};
+extern enum initializing_builtin_options_state initializing_builtin_options_state;
 extern const char *build_option_type_to_s[build_option_type_count];
 bool toolchain_component_option_name(struct workspace *wk, enum compiler_language l, enum toolchain_component c, enum machine_kind machine, struct tstr *dest);
 

--- a/include/options.h
+++ b/include/options.h
@@ -91,6 +91,12 @@ enum backend {
 };
 enum backend get_option_backend(struct workspace *wk);
 
+enum opt_namingscheme {
+	opt_namingscheme_classic,
+	opt_namingscheme_platform,
+};
+enum opt_namingscheme get_option_namingscheme(struct workspace *wk, const struct project *proj, obj overrides);
+
 bool options_load_from_option_info(struct workspace *wk);
 
 struct list_options_opts {

--- a/include/toolchains.h
+++ b/include/toolchains.h
@@ -167,7 +167,7 @@ typedef bool ((*compiler_get_arg_func_1srb)(TOOLCHAIN_SIG_1srb));
 	_(pie, compiler, TOOLCHAIN_PARAMS_0)                       \
 	_(preprocess_only, compiler, TOOLCHAIN_PARAMS_0)           \
 	_(print_search_dirs, compiler, TOOLCHAIN_PARAMS_0)         \
-	_(sanitize, compiler, TOOLCHAIN_PARAMS_1s)                 \
+	_(sanitize, compiler, TOOLCHAIN_PARAMS_ns)                 \
 	_(set_std, compiler, TOOLCHAIN_PARAMS_1s)                  \
 	_(std_unsupported, compiler, TOOLCHAIN_PARAMS_1srb)        \
 	_(version, compiler, TOOLCHAIN_PARAMS_0)                   \
@@ -198,7 +198,7 @@ typedef bool ((*compiler_get_arg_func_1srb)(TOOLCHAIN_SIG_1srb));
 	_(no_undefined, linker, TOOLCHAIN_PARAMS_0)            \
 	_(pgo, linker, TOOLCHAIN_PARAMS_1i)                    \
 	_(rpath, linker, TOOLCHAIN_PARAMS_1s)                  \
-	_(sanitize, linker, TOOLCHAIN_PARAMS_1s)               \
+	_(sanitize, linker, TOOLCHAIN_PARAMS_ns)               \
 	_(shared, linker, TOOLCHAIN_PARAMS_0)                  \
 	_(shared_module, linker, TOOLCHAIN_PARAMS_0)           \
 	_(soname, linker, TOOLCHAIN_PARAMS_1s)                 \

--- a/include/util.h
+++ b/include/util.h
@@ -14,8 +14,13 @@
 #undef MAX
 #endif
 
+#ifdef CLAMP
+#undef CLAMP
+#endif
+
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define CLAMP(a_, min_, max_) (a_ > max_ ? max_ : (a_ < min_ ? min_ : a_))
 
 #define IS_POWER_OF_TWO(__i) ((__i & (__i - 1)) == 0)
 

--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,7 @@ endif
 version_info = configuration_data()
 version_info.set('version', meson.project_version())
 version_info.set('vcs_tag', git_sha)
-version_info.set('meson_compat', '1.7')
+version_info.set('meson_compat', '1.11')
 version_info.set('platform', platform)
 version_info.set('compiler', cc.get_id())
 summary('compiler', cc.get_id())

--- a/src/args.c
+++ b/src/args.c
@@ -12,6 +12,7 @@
 #include "error.h"
 #include "functions/both_libs.h"
 #include "functions/environment.h"
+#include "functions/external_program.h"
 #include "lang/object_iterators.h"
 #include "lang/workspace.h"
 #include "log.h"
@@ -331,10 +332,10 @@ obj_to_args(struct workspace *wk, obj src, enum arr_to_args_flags flags, obj des
 		}
 
 		struct obj_external_program *ep = get_obj_external_program(wk, src);
-		if (is_argv0 && ep->original_argv0) {
-			obj_array_push(wk, dest, ep->original_argv0);
+		if (is_argv0 && ep->impl.original_argv0) {
+			obj_array_push(wk, dest, ep->impl.original_argv0);
 		} else {
-			obj_array_extend(wk, dest, ep->cmd_array);
+			obj_array_extend(wk, dest, obj_external_program_cmd_array(wk, ep, 0));
 		}
 		return true;
 	case obj_compiler:

--- a/src/args.c
+++ b/src/args.c
@@ -258,16 +258,9 @@ relativize_build_file_path(struct workspace *wk, struct tstr *buf, const char *p
 	}
 }
 
-struct arr_to_args_ctx {
-	enum arr_to_args_flags mode;
-	obj res;
-	uint32_t i;
-};
-
-static enum iteration_result
-arr_to_args_iter(struct workspace *wk, void *_ctx, obj src)
+static bool
+obj_to_args(struct workspace *wk, obj src, enum arr_to_args_flags flags, obj dest, bool is_argv0)
 {
-	struct arr_to_args_ctx *ctx = _ctx;
 	obj str;
 
 	enum obj_type t = get_obj_type(wk, src);
@@ -275,7 +268,7 @@ arr_to_args_iter(struct workspace *wk, void *_ctx, obj src)
 	switch (t) {
 	case obj_string: str = src; break;
 	case obj_file:
-		if (ctx->mode & arr_to_args_relativize_paths) {
+		if (flags & arr_to_args_relativize_paths) {
 			TSTR(rel);
 			relativize_build_file_path(wk, &rel, get_file_path(wk, src));
 			str = tstr_into_str(wk, &rel);
@@ -284,7 +277,7 @@ arr_to_args_iter(struct workspace *wk, void *_ctx, obj src)
 		str = *get_obj_file(wk, src);
 		break;
 	case obj_alias_target:
-		if (!(ctx->mode & arr_to_args_alias_target)) {
+		if (!(flags & arr_to_args_alias_target)) {
 			goto type_err;
 		}
 		str = get_obj_alias_target(wk, src)->name;
@@ -292,14 +285,14 @@ arr_to_args_iter(struct workspace *wk, void *_ctx, obj src)
 	case obj_both_libs: src = decay_both_libs(wk, src);
 	/* fallthrough */
 	case obj_build_target: {
-		if (!(ctx->mode & arr_to_args_build_target)) {
+		if (!(flags & arr_to_args_build_target)) {
 			goto type_err;
 		}
 
 		struct obj_build_target *tgt = get_obj_build_target(wk, src);
 
 		TSTR(rel);
-		if (ctx->mode & arr_to_args_relativize_paths) {
+		if (flags & arr_to_args_relativize_paths) {
 			relativize_build_file_path(wk, &rel, get_cstr(wk, tgt->build_path));
 			str = tstr_into_str(wk, &rel);
 		} else {
@@ -309,7 +302,7 @@ arr_to_args_iter(struct workspace *wk, void *_ctx, obj src)
 		break;
 	}
 	case obj_custom_target: {
-		if (!(ctx->mode & arr_to_args_custom_target)) {
+		if (!(flags & arr_to_args_custom_target)) {
 			goto type_err;
 		}
 
@@ -319,51 +312,58 @@ arr_to_args_iter(struct workspace *wk, void *_ctx, obj src)
 		// run_target is a custom_target without an output, so we yield
 		// the target's name and continue.
 		if (!get_obj_type(wk, output_arr)) {
-			obj_array_push(wk, ctx->res, custom_tgt->name);
-			goto cont;
+			obj_array_push(wk, dest, custom_tgt->name);
+			return true;
 		}
 
-		if (!obj_array_foreach(wk, output_arr, ctx, arr_to_args_iter)) {
-			return ir_err;
+		obj v;
+		obj_array_for(wk, output_arr, v) {
+			if (!obj_to_args(wk, v, flags, dest, false)) {
+				return false;
+			}
 		}
-		goto cont;
+		return true;
 	}
 	case obj_external_program:
 	case obj_python_installation:
-		if (!(ctx->mode & arr_to_args_external_program)) {
+		if (!(flags & arr_to_args_external_program)) {
 			goto type_err;
 		}
 
 		struct obj_external_program *ep = get_obj_external_program(wk, src);
-		if (ctx->i > 0 && ep->original_argv0) {
-			obj_array_push(wk, ctx->res, ep->original_argv0);
+		if (is_argv0 && ep->original_argv0) {
+			obj_array_push(wk, dest, ep->original_argv0);
 		} else {
-			obj_array_extend(wk, ctx->res, ep->cmd_array);
+			obj_array_extend(wk, dest, ep->cmd_array);
 		}
-		goto cont;
+		return true;
 	case obj_compiler:
-		obj_array_extend(wk, ctx->res, get_obj_compiler(wk, src)->cmd_arr[toolchain_component_compiler]);
-		goto cont;
+		obj_array_extend(wk, dest, get_obj_compiler(wk, src)->cmd_arr[toolchain_component_compiler]);
+		return true;
 	default:
 type_err:
 		LOG_E("cannot convert '%s' to argument", obj_type_to_s(t));
-		return ir_err;
+		return false;
 	}
 
-	obj_array_push(wk, ctx->res, str);
-cont:
-	++ctx->i;
-	return ir_cont;
+	obj_array_push(wk, dest, str);
+	return true;
 }
 
 bool
-arr_to_args(struct workspace *wk, enum arr_to_args_flags mode, obj arr, obj *res)
+arr_to_args(struct workspace *wk, enum arr_to_args_flags flags, obj arr, obj *res)
 {
 	*res = make_obj(wk, obj_array);
 
-	struct arr_to_args_ctx ctx = { .mode = mode, .res = *res };
-
-	return obj_array_foreach_flat(wk, arr, &ctx, arr_to_args_iter);
+	obj v;
+	uint32_t i = 0;
+	obj_array_flat_for_(wk, arr, v, iter) {
+		if (!obj_to_args(wk, v, flags, *res, i == 0)) {
+			obj_array_flat_iter_end(wk, &iter);
+			return false;
+		}
+	}
+	return true;
 }
 
 struct join_args_argstr_ctx {

--- a/src/backend/backend.c
+++ b/src/backend/backend.c
@@ -103,7 +103,7 @@ base_environment(struct workspace *wk)
 
 		obj_array_dedup_in_place(wk, &paths);
 
-		if (!environment_set(wk, res, environment_set_mode_append, make_str(wk, "PATH"), paths, 0)) {
+		if (!environment_set(wk, res, environment_set_mode_prepend, make_str(wk, "PATH"), paths, 0)) {
 			UNREACHABLE_RETURN;
 		}
 	}

--- a/src/backend/common_args.c
+++ b/src/backend/common_args.c
@@ -268,9 +268,7 @@ ca_setup_optional_b_args_compiler(struct workspace *wk,
 	}
 
 	ca_get_option_value_for_tgt(wk, proj, tgt, "b_sanitize", &opt);
-	if (!str_eql(get_str(wk, opt), &STR("none"))) {
-		obj_array_extend(wk, args, toolchain_compiler_sanitize(wk, comp, get_cstr(wk, opt)));
-	}
+	obj_array_extend(wk, args, toolchain_compiler_sanitize(wk, comp, opt));
 
 	obj buildtype_val;
 	ca_get_option_value_for_tgt(wk, proj, tgt, "buildtype", &buildtype_val);
@@ -622,9 +620,7 @@ ca_setup_optional_b_args_linker(struct workspace *wk,
 	}
 
 	ca_get_option_value_for_tgt(wk, proj, tgt, "b_sanitize", &opt);
-	if (strcmp(get_cstr(wk, opt), "none") != 0) {
-		obj_array_extend(wk, args, toolchain_linker_sanitize(wk, comp, get_cstr(wk, opt)));
-	}
+	obj_array_extend(wk, args, toolchain_linker_sanitize(wk, comp, opt));
 
 	ca_get_option_value_for_tgt(wk, proj, tgt, "b_lto", &opt);
 	if (get_obj_bool(wk, opt)) {
@@ -700,8 +696,7 @@ ca_prepare_target_linker_args(struct workspace *wk,
 			{
 				obj sanitize_opt;
 				ca_get_option_value_for_tgt(wk, proj, tgt, "b_sanitize", &sanitize_opt);
-				if (!str_eql(get_str(wk, sanitize_opt), &STR("none"))
-					&& (tgt->type & tgt_dynamic_library)
+				if (!get_obj_array(wk, sanitize_opt)->len && (tgt->type & tgt_dynamic_library)
 					&& toolchain_compiler_asan_lundef_warning(wk, comp)) {
 					LOG_W("target '%s': the current compiler does not support using b_sanitize and b_lundef together",
 						get_str(wk, tgt->name)->s);

--- a/src/backend/common_args.c
+++ b/src/backend/common_args.c
@@ -61,7 +61,9 @@ ca_get_buildtype(struct workspace *wk,
 		{ NULL } };
 
 	obj buildtype_opt_id, buildtype_val;
-	get_option_overridable(wk, proj, tgt ? tgt->override_options : 0, &STR("buildtype"), &buildtype_opt_id);
+	if (!get_option_overridable(wk, proj, tgt ? tgt->override_options : 0, &STR("buildtype"), &buildtype_opt_id)) {
+		UNREACHABLE;
+	}
 	struct obj_option *buildtype_opt = get_obj_option(wk, buildtype_opt_id);
 	buildtype_val = buildtype_opt->val;
 

--- a/src/backend/introspect.c
+++ b/src/backend/introspect.c
@@ -150,7 +150,10 @@ introspect_build_target(struct workspace *wk, struct project *proj, obj tgt)
 			}
 
 			obj_dict_set(wk, linker_src, make_str(wk, "linker"), comp->cmd_arr[component]);
-			obj_dict_set(wk, linker_src, make_str(wk, "parameters"), t->dep_internal.link_args);
+			obj link_args;
+			obj_array_dup(wk, t->dep_internal.link_early_args, &link_args);
+			obj_array_extend(wk, link_args, t->dep_internal.link_args);
+			obj_dict_set(wk, linker_src, make_str(wk, "parameters"), link_args);
 			obj_array_push(wk, src, linker_src);
 		}
 

--- a/src/backend/ninja.c
+++ b/src/backend/ninja.c
@@ -19,6 +19,7 @@
 #include "backend/output.h"
 #include "error.h"
 #include "external/samurai.h"
+#include "functions/external_program.h"
 #include "functions/kernel.h"
 #include "log.h"
 #include "platform/assert.h"
@@ -247,12 +248,13 @@ ninja_run(struct workspace *wk, obj args, const char *chdir, const char *capture
 		}
 
 		struct obj_external_program *ep = get_obj_external_program(wk, found_ninja);
+		obj cmd_array = obj_external_program_cmd_array(wk, ep, 0);
 
-		if (str_eql(get_str(wk, obj_array_index(wk, ep->cmd_array, 0)), &STRL(wk->argv0))) {
+		if (str_eql(get_str(wk, obj_array_index(wk, cmd_array, 0)), &STRL(wk->argv0))) {
 			use_internal_samurai = true;
 		} else {
 			obj cmd_array_dup;
-			obj_array_dup(wk, ep->cmd_array, &cmd_array_dup);
+			obj_array_dup(wk, cmd_array, &cmd_array_dup);
 			obj_array_extend_nodup(wk, cmd_array_dup, args);
 			args = cmd_array_dup;
 		}

--- a/src/backend/ninja/build_target.c
+++ b/src/backend/ninja/build_target.c
@@ -380,20 +380,23 @@ ninja_write_build_tgt(struct workspace *wk, obj tgt_id, struct write_tgt_ctx *wc
 	TSTR(link_rule);
 	tstr_pushf(wk, &link_rule, "%s_%s_", get_cstr(wk, ctx.proj->rule_prefix), machine_kind_to_s(tgt->machine));
 
-	const char *link_args;
+	const char *link_args = 0, *link_early_args = 0;
 	switch (tgt->type) {
 	case tgt_shared_module:
 	case tgt_dynamic_library:
 	case tgt_executable:
 		tstr_pushf(wk, &link_rule, "%s_linker", compiler_language_to_s(tgt->dep_internal.link_language));
 		link_args = get_cstr(wk, join_args_shell_ninja(wk, ctx.args.link_args));
+
+		if (tgt->dep_internal.link_early_args) {
+			link_early_args = get_cstr(wk, join_args_shell_ninja(wk, ctx.args.link_early_args));
+		}
 		break;
 	case tgt_static_library:
 		if (!get_obj_array(wk, ctx.object_names)->len) {
 			goto done;
 		}
 		tstr_pushs(wk, &link_rule, "archiver");
-		link_args = 0;
 		break;
 	default: UNREACHABLE_RETURN;
 	}
@@ -418,6 +421,9 @@ ninja_write_build_tgt(struct workspace *wk, obj tgt_id, struct write_tgt_ctx *wc
 	if (ctx.have_order_deps) {
 		fputs(" || ", wctx->out);
 		fputs(get_cstr(wk, ctx.order_deps), wctx->out);
+	}
+	if (link_early_args) {
+		fprintf(wctx->out, "\n LINK_EARLY_ARGS = %s", link_early_args);
 	}
 	if (link_args) {
 		fprintf(wctx->out, "\n LINK_ARGS = %s", link_args);

--- a/src/backend/ninja/clang_format.c
+++ b/src/backend/ninja/clang_format.c
@@ -8,6 +8,7 @@
 #include "backend/common_args.h"
 #include "backend/ninja/clang_format.h"
 #include "backend/output.h"
+#include "functions/external_program.h"
 #include "functions/kernel.h"
 #include "lang/object_iterators.h"
 #include "lang/serial.h"
@@ -280,7 +281,7 @@ ninja_clang_format_write_targets(struct workspace *wk, FILE *out)
 		obj command;
 		obj_array_dup(wk, command_base, &command);
 		obj_array_push(wk, command, make_str(wk, "--"));
-		obj_array_extend(wk, command, ep->cmd_array);
+		obj_array_extend(wk, command, obj_external_program_cmd_array(wk, ep, 0));
 		obj joined = join_args_shell_ninja(wk, command);
 
 		ninja_create_phony_clang_format_target(
@@ -292,7 +293,7 @@ ninja_clang_format_write_targets(struct workspace *wk, FILE *out)
 		obj_array_dup(wk, command_base, &command);
 		obj_array_push(wk, command, make_str(wk, "-n"));
 		obj_array_push(wk, command, make_str(wk, "--"));
-		obj_array_extend(wk, command, ep->cmd_array);
+		obj_array_extend(wk, command, obj_external_program_cmd_array(wk, ep, 0));
 		obj joined = join_args_shell_ninja(wk, command);
 
 		ninja_create_phony_clang_format_target(wk,

--- a/src/backend/ninja/rules.c
+++ b/src/backend/ninja/rules.c
@@ -67,7 +67,7 @@ write_linker_rule(struct workspace *wk,
 
 	if (toolchain_compiler_do_linker_passthrough(wk, comp_id)) {
 		obj_array_extend(wk, args, comp->cmd_arr[toolchain_component_compiler]);
-		obj_array_push(wk, args, make_str(wk, "$ARGS"));
+		obj_array_push(wk, args, make_str(wk, "$LINK_EARLY_ARGS"));
 
 		obj_array_extend(wk, args, toolchain_compiler_output(wk, comp_id, "$out"));
 		obj_array_push(wk, args, make_str(wk, "$in"));
@@ -78,7 +78,7 @@ write_linker_rule(struct workspace *wk,
 		}
 
 		obj_array_extend(wk, args, comp->cmd_arr[toolchain_component_linker]);
-		obj_array_push(wk, args, make_str(wk, "$ARGS"));
+		obj_array_push(wk, args, make_str(wk, "$LINK_EARLY_ARGS"));
 		obj_array_extend(wk, args, toolchain_linker_input_output(wk, comp_id, "$in", "$out"));
 		obj_array_push(wk, args, make_str(wk, "$LINK_ARGS"));
 	}

--- a/src/cmd_test.c
+++ b/src/cmd_test.c
@@ -203,7 +203,7 @@ print_test_result(struct workspace *wk, const struct test_result *res)
 	log_raw("%s", name);
 
 	if (status == status_should_have_failed) {
-		log_raw(" - passing test marked as should_fail");
+		log_raw(" - passing test marked as expected_fail");
 	}
 }
 
@@ -612,7 +612,8 @@ ret:
 static enum test_result_status
 check_test_result_exitcode(struct workspace *wk, const struct run_test_ctx *ctx, const struct test_result *res)
 {
-	if (res->cmd_ctx.status == 0) {
+	if (res->cmd_ctx.status
+		== (res->test->expected_exitcode ? get_obj_number(wk, res->test->expected_exitcode) : 0)) {
 		return test_result_status_ok;
 	} else if (res->cmd_ctx.status == 77) {
 		return test_result_status_skipped;

--- a/src/coerce.c
+++ b/src/coerce.c
@@ -30,8 +30,24 @@ coerce_environment_from_kwarg(struct workspace *wk, struct args_kw *kw, bool set
 			*res = kw->val;
 		} else {
 			obj dict;
-			if (!coerce_key_value_dict(wk, kw->node, kw->val, &dict)) {
-				return false;
+			if (get_obj_type(wk, kw->val) == obj_dict) {
+				dict = kw->val;
+				if (!typecheck(wk,
+					    kw->node,
+					    dict,
+					    make_complex_type(wk,
+						    complex_type_nested,
+						    tc_dict,
+						    make_complex_type(wk,
+							    complex_type_or,
+							    tc_string,
+							    complex_type_preset_get(wk, tc_cx_list_of_str))))) {
+					return false;
+				}
+			} else {
+				if (!coerce_key_value_dict(wk, kw->node, kw->val, &dict)) {
+					return false;
+				}
 			}
 
 			*res = make_obj_environment(wk, flags);
@@ -50,62 +66,30 @@ coerce_environment_from_kwarg(struct workspace *wk, struct args_kw *kw, bool set
 	return true;
 }
 
-struct coerce_environment_ctx {
-	uint32_t err_node;
-	obj res;
-};
-
-static enum iteration_result
-coerce_environment_iter(struct workspace *wk, void *_ctx, obj val)
+static bool
+coerce_split_and_push_key_value_string(struct workspace *wk, obj dest, uint32_t err_node, obj val)
 {
-	struct coerce_environment_ctx *ctx = _ctx;
-
-	if (!typecheck(wk, ctx->err_node, val, obj_string)) {
+	if (!typecheck(wk, err_node, val, obj_string)) {
 		return false;
 	}
 
 	const struct str *ss = get_str(wk, val);
 	if (str_has_null(ss)) {
-		vm_error_at(wk, ctx->err_node, "environment string %o must not contain NUL", val);
-		return ir_err;
+		vm_error_at(wk, err_node, "key value string %o must not contain NUL", val);
+		return false;
 	}
 
-	const char *eql;
-	if (!(eql = strchr(ss->s, '='))) {
-		vm_error_at(
-			wk, ctx->err_node, "invalid env element %o; env elements must be of the format key=value", val);
-		return ir_err;
+	struct str_cut cut;
+	if (!str_cut(ss, &STR("="), &cut)) {
+		vm_error_at(wk, err_node, "invalid key value string %o; strings must be of the format key=value", val);
+		return false;
 	}
 
-	uint32_t key_len = eql - ss->s;
-	obj key = make_strn(wk, ss->s, key_len);
-	val = make_strn(wk, ss->s + key_len + 1, ss->len - (key_len + 1));
+	obj key = make_strn(wk, cut.before.s, cut.before.len);
+	val = make_strn(wk, cut.after.s, cut.after.len);
 
-	obj_dict_set(wk, ctx->res, key, val);
-	return ir_cont;
-}
-
-static enum iteration_result
-typecheck_environment_dict_iter(struct workspace *wk, void *_ctx, obj key, obj val)
-{
-	uint32_t err_node = *(uint32_t *)_ctx;
-	const struct str *k = get_str(wk, key), *v = get_str(wk, val);
-
-	if (!k->len) {
-		vm_error_at(wk, err_node, "environment key may not be an empty string (value is '%s')", v->s);
-		return ir_err;
-	} else if (str_has_null(k)) {
-		vm_error_at(wk, err_node, "environment key may not contain NUL");
-		return ir_err;
-	} else if (str_has_null(v)) {
-		vm_error_at(wk, err_node, "environment value may not contain NUL");
-		return ir_err;
-	} else if (strchr(k->s, '=')) {
-		vm_error_at(wk, err_node, "environment key '%s' contains '='", k->s);
-		return ir_err;
-	}
-
-	return ir_cont;
+	obj_dict_set(wk, dest, key, val);
+	return true;
 }
 
 bool
@@ -113,15 +97,19 @@ coerce_key_value_dict(struct workspace *wk, uint32_t err_node, obj val, obj *res
 {
 	*res = make_obj(wk, obj_dict);
 
-	struct coerce_environment_ctx ctx = {
-		.err_node = err_node,
-		.res = *res,
-	};
-
 	enum obj_type t = get_obj_type(wk, val);
 	switch (t) {
-	case obj_string: return coerce_environment_iter(wk, &ctx, val) != ir_err;
-	case obj_array: return obj_array_foreach_flat(wk, val, &ctx, coerce_environment_iter);
+	case obj_string: return coerce_split_and_push_key_value_string(wk, *res, err_node, val);
+	case obj_array: {
+		obj v;
+		obj_array_flat_for_(wk, val, v, iter) {
+			if (!coerce_split_and_push_key_value_string(wk, *res, err_node, v)) {
+				obj_array_flat_iter_end(wk, &iter);
+				return false;
+			}
+		}
+		break;
+	}
 	case obj_dict:
 		if (!typecheck(wk, err_node, val, make_complex_type(wk, complex_type_nested, tc_dict, tc_string))) {
 			return false;
@@ -134,8 +122,24 @@ coerce_key_value_dict(struct workspace *wk, uint32_t err_node, obj val, obj *res
 		return false;
 	}
 
-	if (!obj_dict_foreach(wk, *res, &err_node, typecheck_environment_dict_iter)) {
-		return false;
+	{
+		obj key, val;
+		obj_dict_for(wk, *res, key, val) {
+			const struct str *k = get_str(wk, key), *v = get_str(wk, val);
+			if (!k->len) {
+				vm_error_at(wk, err_node, "key may not be an empty string (value is '%s')", v->s);
+				return false;
+			} else if (str_has_null(k)) {
+				vm_error_at(wk, err_node, "key may not contain NUL");
+				return false;
+			} else if (str_has_null(v)) {
+				vm_error_at(wk, err_node, "value may not contain NUL");
+				return false;
+			} else if (strchr(k->s, '=')) {
+				vm_error_at(wk, err_node, "key '%s' contains '='", k->s);
+				return false;
+			}
+		}
 	}
 
 	return true;

--- a/src/coerce.c
+++ b/src/coerce.c
@@ -12,6 +12,7 @@
 #include "coerce.h"
 #include "functions/both_libs.h"
 #include "functions/environment.h"
+#include "functions/external_program.h"
 #include "lang/object_iterators.h"
 #include "lang/typecheck.h"
 #include "log.h"
@@ -338,13 +339,14 @@ coerce_executable(struct workspace *wk, uint32_t node, obj val, obj *res, obj *a
 			return ir_err;
 		}
 
-		str = obj_array_index(wk, o->cmd_array, 0);
-		uint32_t cmd_array_len = get_obj_array(wk, o->cmd_array)->len;
+		obj cmd_array = obj_external_program_cmd_array(wk, o, 0);
+		str = obj_array_index(wk, cmd_array, 0);
+		uint32_t cmd_array_len = get_obj_array(wk, cmd_array)->len;
 		if (cmd_array_len > 1) {
-			*args = obj_array_slice(wk, o->cmd_array, 1, cmd_array_len);
+			*args = obj_array_slice(wk, cmd_array, 1, cmd_array_len);
 		}
 
-		*original_argv0 = o->original_argv0;
+		*original_argv0 = o->impl.original_argv0;
 		break;
 	}
 	case obj_custom_target: {

--- a/src/coerce.c
+++ b/src/coerce.c
@@ -35,13 +35,8 @@ coerce_environment_from_kwarg(struct workspace *wk, struct args_kw *kw, bool set
 				if (!typecheck(wk,
 					    kw->node,
 					    dict,
-					    make_complex_type(wk,
-						    complex_type_nested,
-						    tc_dict,
-						    make_complex_type(wk,
-							    complex_type_or,
-							    tc_string,
-							    complex_type_preset_get(wk, tc_cx_list_of_str))))) {
+					    make_complex_type(
+						    wk, complex_type_nested, tc_dict, TYPE_TAG_LISTIFY | tc_string))) {
 					return false;
 				}
 			} else {

--- a/src/datastructures/stack.c
+++ b/src/datastructures/stack.c
@@ -9,7 +9,7 @@
 
 #include "arena.h"
 #include "datastructures/stack.h"
-#include "log.h"
+#include "error.h"
 #include "platform/assert.h"
 
 /******************************************************************************
@@ -24,6 +24,8 @@ struct stack_tag {
 	const char *name;
 	uint32_t size;
 };
+#else
+#include "log.h"
 #endif
 
 void
@@ -35,12 +37,15 @@ stack_init(struct arena *a, struct stack *stack, uint32_t cap)
 	};
 }
 
-static void
-stack_push_raw(struct stack *stack, const void *mem, uint32_t size)
+static bool
+stack_try_push_raw(struct stack *stack, const void *mem, uint32_t size)
 {
-	assert(stack->len + size < stack->cap);
-	memcpy(stack->mem + stack->len, mem, size);
-	stack->len += size;
+	if (stack->len + size < stack->cap) {
+		memcpy(stack->mem + stack->len, mem, size);
+		stack->len += size;
+		return true;
+	}
+	return false;
 }
 
 static void
@@ -83,17 +88,30 @@ stack_print(struct stack *_stack)
 #endif
 }
 
-void
-stack_push_sized(struct stack *stack, const void *mem, uint32_t size, const char *name)
+bool
+stack_try_push_sized(struct stack *stack, const void *mem, uint32_t size, const char *name)
 {
-	stack_push_raw(stack, mem, size);
+	if (!stack_try_push_raw(stack, mem, size)) {
+		return false;
+	}
 #if MUON_STACK_SANITIZE
-	stack_push_raw(stack, &(struct stack_tag){ name, size }, sizeof(struct stack_tag));
+	if (!stack_try_push_raw(stack, &(struct stack_tag){ name, size }, sizeof(struct stack_tag))) {
+		return false;
+	}
 
 #if MUON_STACK_DEBUG
 	L("\033[33mstack\033[0m %05d pushed %s (%d)", stack->len, name, size);
 #endif
 #endif
+	return true;
+}
+
+void
+stack_push_sized(struct stack *stack, const void *mem, uint32_t size, const char *name)
+{
+	if (!stack_try_push_sized(stack, mem, size, name)) {
+		error_unrecoverable("stack overflow");
+	}
 }
 
 void

--- a/src/external/pkgconfig_exec.c
+++ b/src/external/pkgconfig_exec.c
@@ -11,6 +11,7 @@
 #include "buf_size.h"
 #include "external/pkgconfig.h"
 #include "functions/environment.h"
+#include "functions/external_program.h"
 #include "functions/kernel.h"
 #include "lang/object_iterators.h"
 #include "log.h"
@@ -37,7 +38,7 @@ pkgconfig_cmd(struct workspace *wk, struct run_cmd_ctx *rctx, obj extra_args, en
 		}
 
 		if (ctx.found) {
-			pkgconfig_cmd_arr = get_obj_external_program(wk, prog)->cmd_array;
+			pkgconfig_cmd_arr = obj_external_program_cmd_array(wk, get_obj_external_program(wk, prog), 0);
 		}
 	}
 

--- a/src/functions/array.c
+++ b/src/functions/array.c
@@ -100,30 +100,109 @@ FUNC_IMPL(array, delete, 0, func_impl_flag_impure)
 	return true;
 }
 
+static int64_t
+python_slice_clamp(int64_t v, int64_t lower, int64_t upper, int64_t len)
+{
+	if (v < 0) {
+		v += len;
+		if (v < lower) {
+			v = lower;
+		}
+	} else {
+		if (v > upper) {
+			v = upper;
+		}
+	}
+	return v;
+}
+
 FUNC_IMPL(array, slice, tc_array)
 {
-	struct args_norm an[] = { { obj_number, .optional = true }, { obj_number, .optional = true }, ARG_TYPE_NULL };
-	if (!pop_args(wk, an, NULL)) {
+	struct args_norm an[] = {
+		{ obj_number, .optional = true },
+		{ obj_number, .optional = true },
+		ARG_TYPE_NULL,
+	};
+	enum kwargs {
+		kw_step,
+	};
+	struct args_kw akw[] = {
+		[kw_step] = { "step", tc_number },
+		0,
+	};
+	if (!pop_args(wk, an, akw)) {
 		return false;
 	}
 
 	const struct obj_array *a = get_obj_array(wk, self);
-	int64_t start = 0, end = a->len;
+	int64_t step = akw[kw_step].set ? get_obj_number(wk, akw[kw_step].val) : 1;
 
-	if (an[0].set) {
-		start = get_obj_number(wk, an[0].val);
+	if (step == 0) {
+		vm_error_at(wk, akw[kw_step].node, "step cannot be 0");
+		return false;
 	}
 
-	if (an[1].set) {
-		end = get_obj_number(wk, an[1].val);
+	if (step == 1) {
+		// If step == 1 then we can use obj_array_slice which can reuse memory
+		// from the original array
+		int64_t start = 0, end = a->len;
+
+		if (an[0].set) {
+			start = get_obj_number(wk, an[0].val);
+		}
+
+		if (an[1].set) {
+			end = get_obj_number(wk, an[1].val);
+		}
+
+		bounds_adjust(a->len, &start);
+		bounds_adjust(a->len, &end);
+
+		start = CLAMP(start, 0, a->len);
+		end = CLAMP(end, 0, a->len);
+		*res = obj_array_slice(wk, self, start, end);
+	} else {
+		// If step != 1 then we have to do the tortured python slice/range
+		// clipping and create a new array.
+		*res = make_obj(wk, obj_array);
+		int64_t lower, upper, start, end;
+
+		if (step < 0) {
+			lower = -1;
+			upper = a->len - 1;
+		} else {
+			lower = 0;
+			upper = a->len;
+		}
+
+		if (!an[0].set) {
+			start = step < 0 ? upper : lower;
+		} else {
+			start = python_slice_clamp(get_obj_number(wk, an[0].val), lower, upper, a->len);
+		}
+
+		if (!an[1].set) {
+			end = step < 0 ? lower : upper;
+		} else {
+			end = python_slice_clamp(get_obj_number(wk, an[1].val), lower, upper, a->len);
+		}
+
+		if (step > 0 && start >= end) {
+			// empty slice
+			return true;
+		} else if (step < 0 && start <= end) {
+			// empty slice
+			return true;
+		}
+
+		for (int64_t i = start; step > 0 ? i < end : i > end; i += step) {
+			if (i < 0) {
+				i += a->len;
+			}
+			obj v = obj_array_index(wk, self, i);
+			obj_array_push(wk, *res, v);
+		}
 	}
-
-	bounds_adjust(a->len, &start);
-	bounds_adjust(a->len, &end);
-
-	end = MIN(end, a->len);
-
-	*res = obj_array_slice(wk, self, start, end);
 	return true;
 }
 
@@ -167,10 +246,10 @@ FUNC_REGISTER(array)
 	FUNC_IMPL_REGISTER(array, get);
 	FUNC_IMPL_REGISTER(array, contains);
 	FUNC_IMPL_REGISTER(array, flatten);
+	FUNC_IMPL_REGISTER(array, slice);
 
 	if (lang_mode == language_internal) {
 		FUNC_IMPL_REGISTER(array, delete);
-		FUNC_IMPL_REGISTER(array, slice);
 		FUNC_IMPL_REGISTER(array, clear);
 		FUNC_IMPL_REGISTER(array, dedup);
 	}

--- a/src/functions/array.c
+++ b/src/functions/array.c
@@ -166,12 +166,12 @@ FUNC_REGISTER(array)
 	FUNC_IMPL_REGISTER(array, length);
 	FUNC_IMPL_REGISTER(array, get);
 	FUNC_IMPL_REGISTER(array, contains);
+	FUNC_IMPL_REGISTER(array, flatten);
 
 	if (lang_mode == language_internal) {
 		FUNC_IMPL_REGISTER(array, delete);
 		FUNC_IMPL_REGISTER(array, slice);
 		FUNC_IMPL_REGISTER(array, clear);
 		FUNC_IMPL_REGISTER(array, dedup);
-		FUNC_IMPL_REGISTER(array, flatten);
 	}
 }

--- a/src/functions/both_libs.c
+++ b/src/functions/both_libs.c
@@ -23,7 +23,7 @@ decay_both_libs(struct workspace *wk, obj both_libs)
 	enum default_both_libraries def_both_libs = b->default_both_libraries;
 
 	if (def_both_libs == default_both_libraries_auto) {
-		 def_both_libs = get_option_default_both_libraries(wk, 0, 0);
+		 def_both_libs = get_option_default_both_libraries(wk, current_project(wk), 0);
 	}
 
 	switch(def_both_libs) {

--- a/src/functions/compiler.c
+++ b/src/functions/compiler.c
@@ -1725,6 +1725,25 @@ FUNC_IMPL(compiler, run, tc_run_result, func_impl_flag_impure)
 }
 
 static bool
+compiler_warning_arg_needs_value_suffix(const struct str *arg_str)
+{
+	const struct str known[] = {
+		STR("alloc-size-larger-than"),
+		STR("alloca-larger-than"),
+		STR("frame-larger-than"),
+		STR("stack-usage"),
+		STR("vla-larger-than"),
+	};
+
+	for (uint32_t i = 0; i < ARRAY_LEN(known); ++i) {
+		if (str_eql(arg_str, &known[i])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool
 compiler_has_argument(struct workspace *wk,
 	obj comp_id,
 	uint32_t err_node,
@@ -1746,6 +1765,8 @@ compiler_has_argument(struct workspace *wk,
 			if (str_startswith(&arg_str, &STR("attributes"))) {
 				// Exclude the special case "-Wno-attributes=...".
 				// See: meson-tests/common/104 has arg/meson.build
+			} else if (compiler_warning_arg_needs_value_suffix(&arg_str)) {
+				arg = make_strf(wk, "-W%.*s=1000", arg_str.len, arg_str.s);
 			} else {
 				arg = make_strf(wk, "-W%.*s", arg_str.len, arg_str.s);
 			}

--- a/src/functions/compiler.c
+++ b/src/functions/compiler.c
@@ -213,7 +213,7 @@ compiler_check(struct workspace *wk, struct compiler_check_opts *opts, const cha
 			struct obj_build_target tgt = {
 				.dep_internal = dep,
 			};
-			ca_prepare_target_linker_args(wk, comp, 0, &tgt, false);
+			ca_prepare_target_linker_args(wk, comp, current_project(wk), &tgt, false);
 			obj_array_extend_nodup(wk, compiler_args, dep.link_args);
 		}
 	}

--- a/src/functions/compiler.c
+++ b/src/functions/compiler.c
@@ -678,6 +678,11 @@ get_has_function_attribute_test(const struct str *name, const char **res)
 		{ "const", "int foo(void) __attribute__((const));\n" },
 		{ "constructor", "int foo(void) __attribute__((constructor));\n" },
 		{ "constructor_priority", "int foo( void ) __attribute__((__constructor__(65535/2)));\n" },
+		{ "counted_by",
+			"struct foo {\n"
+			"    unsigned int count;\n"
+			"    char bar[] __attribute__((counted_by(count)));\n"
+			"};\n" },
 		{ "deprecated", "int foo(void) __attribute__((deprecated(\"\")));\n" },
 		{ "destructor", "int foo(void) __attribute__((destructor));\n" },
 		{ "dllexport", "__declspec(dllexport) int foo(void) { return 0; }\n" },

--- a/src/functions/dict.c
+++ b/src/functions/dict.c
@@ -6,17 +6,8 @@
 #include "compat.h"
 
 #include "functions/dict.h"
+#include "lang/object_iterators.h"
 #include "lang/typecheck.h"
-
-static enum iteration_result
-dict_keys_iter(struct workspace *wk, void *_ctx, obj k, obj v)
-{
-	obj *arr = _ctx;
-
-	obj_array_push(wk, *arr, k);
-
-	return ir_cont;
-}
 
 FUNC_IMPL(dict, keys, tc_array)
 {
@@ -25,7 +16,27 @@ FUNC_IMPL(dict, keys, tc_array)
 	}
 
 	*res = make_obj(wk, obj_array);
-	obj_dict_foreach(wk, self, res, dict_keys_iter);
+	obj k, v;
+	obj_dict_for(wk, self, k, v) {
+		(void)v;
+		obj_array_push(wk, *res, k);
+	}
+
+	return true;
+}
+
+FUNC_IMPL(dict, values, tc_array)
+{
+	if (!pop_args(wk, NULL, NULL)) {
+		return false;
+	}
+
+	*res = make_obj(wk, obj_array);
+	obj k, v;
+	obj_dict_for(wk, self, k, v) {
+		(void)k;
+		obj_array_push(wk, *res, v);
+	}
 
 	return true;
 }
@@ -88,6 +99,7 @@ FUNC_IMPL(dict, set, 0, func_impl_flag_impure)
 FUNC_REGISTER(dict)
 {
 	FUNC_IMPL_REGISTER(dict, keys);
+	FUNC_IMPL_REGISTER(dict, values);
 	FUNC_IMPL_REGISTER(dict, has_key);
 	FUNC_IMPL_REGISTER(dict, get);
 

--- a/src/functions/external_program.c
+++ b/src/functions/external_program.c
@@ -6,34 +6,78 @@
 #include "compat.h"
 
 #include "args.h"
+#include "error.h"
 #include "functions/external_program.h"
 #include "guess.h"
 #include "lang/func_lookup.h"
+#include "lang/object_iterators.h"
 #include "lang/typecheck.h"
 #include "log.h"
+#include "platform/path.h"
 #include "platform/run_cmd.h"
 
-void
-find_program_guess_version(struct workspace *wk, obj cmd_array, obj version_argument, obj *ver)
+obj
+obj_external_program_cmd_array(struct workspace *wk,
+	struct obj_external_program *ep,
+	enum obj_external_program_cmd_array_flag flags)
 {
-	*ver = 0;
+	if (ep->impl.build_target) {
+		switch (get_obj_type(wk, ep->impl.build_target)) {
+		case obj_build_target: {
+			struct obj_build_target *tgt = get_obj_build_target(wk, ep->impl.build_target);
+			ep->impl.cmd_array = make_obj(wk, obj_array);
+			TSTR(abs);
+			path_join(wk, &abs, get_cstr(wk, tgt->build_dir), get_cstr(wk, tgt->build_name));
+			obj_array_push(wk, ep->impl.cmd_array, tstr_into_str(wk, &abs));
+			break;
+		}
+		case obj_custom_target: {
+			struct obj_custom_target *tgt = get_obj_custom_target(wk, ep->impl.build_target);
+			ep->impl.cmd_array = make_obj(wk, obj_array);
+			obj v;
+			obj_array_for(wk, tgt->output, v) {
+				obj_array_push(wk, ep->impl.cmd_array, *get_obj_file(wk, v));
+			}
+			break;
+		}
+		default: UNREACHABLE;
+		}
+	}
 
-	struct run_cmd_ctx cmd_ctx = { 0 };
+	if (ep->impl.cmd_array) {
+		return ep->impl.cmd_array;
+	} else {
+		UNREACHABLE_RETURN;
+	}
+}
+
+void
+find_program_guess_version(struct workspace *wk, struct obj_external_program *ep, obj version_argument)
+{
+	if (ep->ver) {
+		return;
+	}
+
 	obj args;
-	obj_array_dup(wk, cmd_array, &args);
+	obj_array_dup(wk, obj_external_program_cmd_array(wk, ep, 0), &args);
 	obj_array_push(wk, args, version_argument ? version_argument : make_str(wk, "--version"));
 
 	const char *argstr;
 	uint32_t argc;
 	join_args_argstr(wk, &argstr, &argc, args);
 
+	bool got_version = false;
+	struct run_cmd_ctx cmd_ctx = { 0 };
 	if (run_cmd(wk, &cmd_ctx, argstr, argc, NULL, 0) && cmd_ctx.status == 0) {
-		if (!guess_version(wk, cmd_ctx.out.buf, ver)) {
-			*ver = make_str(wk, "unknown");
+		if (guess_version(wk, cmd_ctx.out.buf, &ep->ver)) {
+			got_version = true;
 		}
 	}
-
 	run_cmd_ctx_destroy(&cmd_ctx);
+
+	if (!got_version) {
+		ep->ver = make_str(wk, "unknown");
+	}
 }
 
 FUNC_IMPL(external_program, cmd_array, tc_array, func_impl_flag_impure)
@@ -42,7 +86,7 @@ FUNC_IMPL(external_program, cmd_array, tc_array, func_impl_flag_impure)
 		return false;
 	}
 
-	*res = get_obj_external_program(wk, self)->cmd_array;
+	*res = obj_external_program_cmd_array(wk, get_obj_external_program(wk, self), 0);
 	return true;
 }
 
@@ -64,19 +108,20 @@ FUNC_IMPL(external_program, full_path, tc_string, func_impl_flag_impure)
 
 	struct obj_external_program *ep = get_obj_external_program(wk, self);
 
-	if (ep->original_argv0) {
-		*res = ep->original_argv0;
+	if (ep->impl.original_argv0) {
+		*res = ep->impl.original_argv0;
 		return true;
 	}
 
-	if (get_obj_array(wk, ep->cmd_array)->len > 1) {
+	obj cmd_array = obj_external_program_cmd_array(wk, get_obj_external_program(wk, self), 0);
+	if (get_obj_array(wk, cmd_array)->len > 1) {
 		vm_error(wk,
 			"cannot return the full_path() of an external program with multiple elements (have: %o)\n",
-			ep->cmd_array);
+			cmd_array);
 		return false;
 	}
 
-	*res = obj_array_index(wk, get_obj_external_program(wk, self)->cmd_array, 0);
+	*res = obj_array_get_head(wk, cmd_array);
 	return true;
 }
 
@@ -86,13 +131,9 @@ FUNC_IMPL(external_program, version, tc_string, func_impl_flag_impure)
 		return false;
 	}
 
-	struct obj_external_program *prog = get_obj_external_program(wk, self);
-	if (!prog->guessed_ver) {
-		find_program_guess_version(wk, prog->cmd_array, 0, &prog->ver);
-		prog->guessed_ver = true;
-	}
-
-	*res = prog->ver;
+	struct obj_external_program *ep = get_obj_external_program(wk, self);
+	find_program_guess_version(wk, ep, 0);
+	*res = ep->ver;
 	return true;
 }
 

--- a/src/functions/external_program.c
+++ b/src/functions/external_program.c
@@ -36,6 +36,16 @@ find_program_guess_version(struct workspace *wk, obj cmd_array, obj version_argu
 	run_cmd_ctx_destroy(&cmd_ctx);
 }
 
+FUNC_IMPL(external_program, cmd_array, tc_array, func_impl_flag_impure)
+{
+	if (!pop_args(wk, NULL, NULL)) {
+		return false;
+	}
+
+	*res = get_obj_external_program(wk, self)->cmd_array;
+	return true;
+}
+
 FUNC_IMPL(external_program, found, tc_bool, func_impl_flag_impure)
 {
 	if (!pop_args(wk, NULL, NULL)) {
@@ -88,8 +98,9 @@ FUNC_IMPL(external_program, version, tc_string, func_impl_flag_impure)
 
 FUNC_REGISTER(external_program)
 {
+	FUNC_IMPL_REGISTER(external_program, cmd_array);
 	FUNC_IMPL_REGISTER(external_program, found);
 	FUNC_IMPL_REGISTER(external_program, full_path);
-	FUNC_IMPL_REGISTER_ALIAS(external_program, full_path, path);
 	FUNC_IMPL_REGISTER(external_program, version);
+	FUNC_IMPL_REGISTER_ALIAS(external_program, full_path, path);
 }

--- a/src/functions/kernel.c
+++ b/src/functions/kernel.c
@@ -1570,6 +1570,8 @@ add_test_common(struct workspace *wk, enum test_category cat)
 		kw_workdir,
 		kw_depends,
 		kw_should_fail,
+		kw_expected_fail,
+		kw_expected_exitcode,
 		kw_env,
 		kw_suite,
 		kw_priority,
@@ -1583,6 +1585,8 @@ add_test_common(struct workspace *wk, enum test_category cat)
 		[kw_workdir] = { "workdir", obj_string, },
 		[kw_depends] = { "depends", tc_depends_kw, },
 		[kw_should_fail] = { "should_fail", obj_bool, },
+		[kw_expected_fail] = { "expected_fail", obj_bool, },
+		[kw_expected_exitcode] = { "expected_exitcode", obj_number, },
 		[kw_env] = { "env", tc_coercible_env, },
 		[kw_suite] = { "suite", TYPE_TAG_LISTIFY | obj_string },
 		[kw_priority] = { "priority", obj_number, },
@@ -1664,7 +1668,6 @@ add_test_common(struct workspace *wk, enum test_category cat)
 	t->name = an[0].val;
 	t->exe = exe;
 	t->args = args;
-	t->should_fail = akw[kw_should_fail].set && get_obj_bool(wk, akw[kw_should_fail].val);
 	t->suites = akw[kw_suite].val;
 	t->workdir = akw[kw_workdir].val;
 	t->timeout = akw[kw_timeout].val;
@@ -1672,6 +1675,16 @@ add_test_common(struct workspace *wk, enum test_category cat)
 	t->category = cat;
 	t->protocol = protocol;
 	t->verbose = akw[kw_verbose].set && get_obj_bool(wk, akw[kw_verbose].val);
+	t->expected_exitcode = akw[kw_expected_exitcode].val;
+
+	if (akw[kw_should_fail].set && akw[kw_expected_fail].set) {
+		vm_error_at(wk, akw[kw_should_fail].node, "should_fail cannot be used if expected_fail is set");
+		return false;
+	} else if (akw[kw_should_fail].set) {
+		t->should_fail = get_obj_bool(wk, akw[kw_should_fail].val);
+	} else if (akw[kw_expected_fail].set) {
+		t->should_fail = get_obj_bool(wk, akw[kw_expected_fail].val);
+	}
 
 	if (akw[kw_is_parallel].key) {
 		t->is_parallel = akw[kw_is_parallel].set ? get_obj_bool(wk, akw[kw_is_parallel].val) : true;

--- a/src/functions/kernel.c
+++ b/src/functions/kernel.c
@@ -1166,12 +1166,14 @@ FUNC_IMPL(kernel, run_command, tc_run_result, func_impl_flag_impure | func_impl_
 		kw_check,
 		kw_env,
 		kw_capture,
+		kw_console,
 		kw_feed,
 	};
 	struct args_kw akw[] = {
 		[kw_check] = { "check", obj_bool },
 		[kw_env] = { "env", tc_coercible_env },
 		[kw_capture] = { "capture", obj_bool },
+		[kw_console] = { "console", obj_bool },
 		[kw_feed] = { "feed",
 			tc_coercible_files,
 			.desc = "Specify a file to be used for stdin",
@@ -1254,7 +1256,15 @@ FUNC_IMPL(kernel, run_command, tc_run_result, func_impl_flag_impure | func_impl_
 		.stdin_path = feed ? get_file_path(wk, feed) : 0,
 	};
 
-	if (!capture) {
+	if (capture) {
+		// We only have to worry about console if capture is true, since when
+		// capture is false, console is implicitly false
+		//
+		// NOTE: this won't support capture: false, console: false (e.g. >/dev/null 2>&1)
+		if (get_obj_bool_with_default(wk, akw[kw_console].val, false)) {
+			cmd_ctx.flags |= run_cmd_ctx_flag_tee;
+		}
+	} else {
 		cmd_ctx.flags |= run_cmd_ctx_flag_dont_capture;
 		// Ensure any pending logs are printed prior to this command's execution.
 		log_flush();
@@ -1272,7 +1282,7 @@ FUNC_IMPL(kernel, run_command, tc_run_result, func_impl_flag_impure | func_impl_
 		goto ret;
 	}
 
-	if (akw[kw_check].set && get_obj_bool(wk, akw[kw_check].val) && cmd_ctx.status != 0) {
+	if (get_obj_bool_with_default(wk, akw[kw_check].val, false) && cmd_ctx.status != 0) {
 		vm_error(wk, "command failed");
 		if (cmd_ctx.out.len) {
 			log_plain(log_info, "stdout:\n%s", cmd_ctx.out.buf);

--- a/src/functions/kernel.c
+++ b/src/functions/kernel.c
@@ -6,6 +6,7 @@
 
 #include "compat.h"
 
+#include "lang/object.h"
 #include <string.h>
 
 #include "args.h"
@@ -575,49 +576,19 @@ find_program_check_override(struct workspace *wk, struct find_program_ctx *ctx, 
 	if (!obj_dict_index(wk, wk->find_program_overrides[ctx->machine], prog, &override)) {
 		return true;
 	}
-
-	obj override_version = 0, op;
-	switch (get_obj_type(wk, override)) {
-	case obj_array:
-		op = obj_array_index(wk, override, 0);
-		override_version = obj_array_index(wk, override, 1);
-		break;
-	case obj_python_installation:
-	case obj_external_program:
-		op = override;
-		struct obj_external_program *ep = get_obj_external_program(wk, op);
-
-		if (!ep->found) {
-			return true;
-		}
-
-		if (ctx->version) {
-			find_program_guess_version(wk, ep->cmd_array, ctx->version_argument, &override_version);
-		}
-		break;
-	default: UNREACHABLE;
+	struct obj_external_program *ep = get_obj_external_program(wk, override);
+	if (!ep->found) {
+		return true;
 	}
 
-	if (ctx->version && override_version) {
-		if (!version_compare_list(wk, get_str(wk, override_version), ctx->version)) {
+	if (ctx->version && ep->ver) {
+		if (!version_compare_list(wk, get_str(wk, ep->ver), ctx->version)) {
 			return true;
 		}
-	}
-
-	if (get_obj_type(wk, op) == obj_file) {
-		obj newres;
-		newres = make_obj(wk, obj_external_program);
-		struct obj_external_program *ep = get_obj_external_program(wk, newres);
-		ep->found = true;
-		ep->cmd_array = make_obj(wk, obj_array);
-		ep->guessed_ver = true;
-		ep->ver = override_version;
-		obj_array_push(wk, ep->cmd_array, *get_obj_file(wk, op));
-		op = newres;
 	}
 
 	ctx->found = true;
-	*ctx->res = op;
+	*ctx->res = override;
 	return true;
 }
 
@@ -676,7 +647,6 @@ find_program(struct workspace *wk, struct find_program_ctx *ctx, obj prog)
 {
 	const char *str;
 	obj ver = 0;
-	bool guessed_ver = false;
 	obj cmd_array = 0;
 
 	type_tag tc_allowed = tc_file | tc_string | tc_external_program | tc_python_installation;
@@ -739,9 +709,8 @@ find_program(struct workspace *wk, struct find_program_ctx *ctx, obj prog)
 			*ctx->res = make_obj(wk, obj_external_program);
 			struct obj_external_program *ep = get_obj_external_program(wk, *ctx->res);
 			ep->found = true;
-			ep->cmd_array = cmd_array;
+			ep->impl.cmd_array = cmd_array;
 			ep->ver = ver;
-			ep->guessed_ver = true;
 			ctx->found = true;
 			return true;
 		}
@@ -854,10 +823,9 @@ find_program_step_8:
 			*ctx->res = make_obj(wk, obj_external_program);
 			struct obj_external_program *ep = get_obj_external_program(wk, *ctx->res);
 			ep->found = true;
-			ep->cmd_array = make_obj(wk, obj_array);
-			obj_array_push(wk, ep->cmd_array, make_str(wk, wk->argv0));
-			obj_array_push(wk, ep->cmd_array, make_str(wk, "samu"));
-			ep->guessed_ver = true;
+			ep->impl.cmd_array = make_obj(wk, obj_array);
+			obj_array_push(wk, ep->impl.cmd_array, make_str(wk, wk->argv0));
+			obj_array_push(wk, ep->impl.cmd_array, make_str(wk, "samu"));
 			ep->ver = ver;
 			ctx->found = true;
 			return true;
@@ -893,23 +861,22 @@ found: {
 		}
 	}
 
-	if (ctx->version) {
-		find_program_guess_version(wk, cmd_array, ctx->version_argument, &ver);
-		guessed_ver = true;
+	obj prog = make_obj(wk, obj_external_program);
+	struct obj_external_program *ep = get_obj_external_program(wk, prog);
+	ep->found = true;
+	ep->impl.cmd_array = cmd_array;
+	ep->ver = ver;
+	ep->impl.original_argv0 = original_argv0;
 
-		if (!find_program_check_version(wk, ctx, ver)) {
+	if (ctx->version) {
+		find_program_guess_version(wk, ep, ctx->version_argument);
+
+		if (!find_program_check_version(wk, ctx, ep->ver)) {
 			return true;
 		}
 	}
 
-	*ctx->res = make_obj(wk, obj_external_program);
-	struct obj_external_program *ep = get_obj_external_program(wk, *ctx->res);
-	ep->found = true;
-	ep->cmd_array = cmd_array;
-	ep->guessed_ver = guessed_ver;
-	ep->ver = ver;
-	ep->original_argv0 = original_argv0;
-
+	*ctx->res = prog;
 	ctx->found = true;
 	return true;
 }
@@ -1219,6 +1186,9 @@ FUNC_IMPL(kernel, run_command, tc_run_result, func_impl_flag_impure | func_impl_
 				return false;
 			} else if (!find_program_ctx.found) {
 				vm_error(wk, "unable to find program %o", arg0);
+				return false;
+			} else if (get_obj_external_program(wk, cmd_file)->impl.build_target) {
+				vm_error(wk, "unable to use build target %o as argv0 during setup", cmd_file);
 				return false;
 			}
 			obj_array_set(wk, an[0].val, 0, cmd_file);

--- a/src/functions/kernel.c
+++ b/src/functions/kernel.c
@@ -6,7 +6,6 @@
 
 #include "compat.h"
 
-#include "lang/workspace.h"
 #include <string.h>
 
 #include "args.h"
@@ -1511,6 +1510,35 @@ FUNC_IMPL(kernel, add_test_setup, 0, func_impl_flag_impure)
 	return true;
 }
 
+static bool
+add_test_dep_lib_path_to_env(struct workspace *wk, struct obj_test *t, struct obj_build_target *tgt)
+{
+	if (!(tgt->type == tgt_dynamic_library || tgt->type == tgt_shared_module)) {
+		return true;
+	}
+
+	const char *env_var = 0;
+	switch (machine_definitions[tgt->machine]->sys) {
+	case machine_system_darwin: env_var = "DYLD_LIBRARY_PATH"; break;
+	case machine_system_windows: break;
+	default: env_var = "LD_LIBRARY_PATH"; break;
+	}
+
+	if (!env_var) {
+		return true;
+	}
+
+	TSTR(rel);
+	relativize_build_file_path(wk, &rel, get_cstr(wk, tgt->build_dir));
+
+	if (!environment_set(
+		    wk, t->env, environment_set_mode_prepend, make_str(wk, env_var), tstr_into_str(wk, &rel), 0)) {
+		return false;
+	}
+
+	return true;
+}
+
 struct add_test_depends_ctx {
 	struct obj_test *t;
 	bool from_custom_tgt;
@@ -1546,6 +1574,10 @@ add_test_depends_iter(struct workspace *wk, void *_ctx, obj val)
 
 		relativize_build_file_path(wk, &rel, get_cstr(wk, tgt->build_path));
 		obj_array_push(wk, ctx->t->depends, tstr_into_str(wk, &rel));
+
+		if (!add_test_dep_lib_path_to_env(wk, ctx->t, tgt)) {
+			return ir_err;
+		}
 		break;
 	}
 	case obj_custom_target:

--- a/src/functions/kernel.c
+++ b/src/functions/kernel.c
@@ -1113,8 +1113,8 @@ func_log_common(struct workspace *wk, enum log_level lvl)
 	}
 
 	obj val;
-	obj_array_for(wk, an[0].val, val) {
-		obj_lprintf(wk, lvl, "%#o ", val);
+	obj_array_for_(wk, an[0].val, val, iter) {
+		obj_lprintf(wk, lvl, "%#o%s", val, iter.i + 1 < iter.len ? " " : "");
 	}
 	log_plain(lvl, "\n");
 

--- a/src/functions/kernel.c
+++ b/src/functions/kernel.c
@@ -611,6 +611,8 @@ find_program_check_override(struct workspace *wk, struct find_program_ctx *ctx, 
 		struct obj_external_program *ep = get_obj_external_program(wk, newres);
 		ep->found = true;
 		ep->cmd_array = make_obj(wk, obj_array);
+		ep->guessed_ver = true;
+		ep->ver = override_version;
 		obj_array_push(wk, ep->cmd_array, *get_obj_file(wk, op));
 		op = newres;
 	}

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -599,7 +599,7 @@ create_target(struct workspace *wk,
 
 	{ // dep internal setup
 		enum build_dep_flag flags = 0;
-		if (get_option_default_both_libraries(wk, 0, 0) == default_both_libraries_auto) {
+		if (get_option_default_both_libraries(wk, current_project(wk), 0) == default_both_libraries_auto) {
 			if (tgt->type & tgt_static_library) {
 				flags |= build_dep_flag_both_libs_static;
 				flags |= build_dep_flag_recursive;

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -66,6 +66,7 @@ enum build_target_kwargs {
 	bt_kw_link_early_args,
 	bt_kw_build_subdir,
 	bt_kw_android_exe_type, // TODO
+	bt_kw_shortname, // TODO (https://en.wikipedia.org/wiki/8.3_filename)
 
 #define E(lang, s) bt_kw_##lang##s
 #define TOOLCHAIN_ENUM(lang) E(lang, _args), E(lang, _static_args), E(lang, _shared_args), E(lang, _pch),
@@ -1174,6 +1175,7 @@ tgt_common(struct workspace *wk, obj *res, enum tgt_type type, enum tgt_type arg
 		[bt_kw_link_early_args] = { "link_early_args", TYPE_TAG_LISTIFY | obj_string },
 		[bt_kw_build_subdir] = { "build_subdir", obj_string },
 		[bt_kw_android_exe_type] = { "android_exe_type", obj_string },
+		[bt_kw_shortname] = { "shortname", obj_string },
 #define E(lang, s, t) [bt_kw_##lang##s] = { #lang #s, t }
 #define TOOLCHAIN_ENUM(lang)                                                                                 \
 	E(lang, _args, TYPE_TAG_LISTIFY | obj_string), E(lang, _static_args, TYPE_TAG_LISTIFY | obj_string), \

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -37,6 +37,9 @@ enum build_target_kwargs {
 	bt_kw_install_dir,
 	bt_kw_install_mode,
 	bt_kw_install_tag,
+	bt_kw_install_vala_gir,
+	bt_kw_install_vala_header,
+	bt_kw_install_vala_vapi,
 	bt_kw_link_with,
 	bt_kw_link_whole,
 	bt_kw_version,
@@ -1159,6 +1162,9 @@ tgt_common(struct workspace *wk, obj *res, enum tgt_type type, enum tgt_type arg
 		[bt_kw_install_dir] = { "install_dir", obj_string },
 		[bt_kw_install_mode] = { "install_mode", tc_install_mode_kw },
 		[bt_kw_install_tag] = { "install_tag", tc_string }, // TODO
+		[bt_kw_install_vala_gir] = { "install_vala_gir", tc_string | tc_bool }, // TODO
+		[bt_kw_install_vala_header] = { "install_vala_header", tc_string | tc_bool }, // TODO
+		[bt_kw_install_vala_vapi] = { "install_vala_vapi", tc_string | tc_bool }, // TODO
 		[bt_kw_link_with] = { "link_with", tc_link_with_kw },
 		[bt_kw_link_whole] = { "link_whole", tc_link_with_kw },
 		[bt_kw_version] = { "version", obj_string },

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -371,7 +371,10 @@ setup_implib_and_defs(struct workspace *wk, struct obj_build_target *tgt, const 
 			suffix = toolchain_compiler_flatten_one_optional(wk, toolchain_linker_implib_suffix(wk, comp));
 		}
 		if (!suffix) {
-			suffix = "-implib.lib";
+			switch (get_option_namingscheme(wk, current_project(wk), tgt->override_options)) {
+			case opt_namingscheme_classic: suffix = "-implib.lib"; break;
+			case opt_namingscheme_platform: suffix = ".dll.lib"; break;
+			}
 		}
 		TSTR(implib);
 		tstr_pushf(wk, &implib, "%s%s", plain_name, suffix);
@@ -478,7 +481,18 @@ determine_target_build_name(struct workspace *wk,
 		} else {
 			pref = "lib";
 		}
-		suff = "a";
+
+		switch (get_option_namingscheme(wk, current_project(wk), tgt->override_options)) {
+		case opt_namingscheme_classic: suff = "a"; break;
+		case opt_namingscheme_platform: {
+			if (machine_definitions[tgt->machine]->is_windows) {
+				suff = "lib";
+			} else {
+				suff = "a";
+			}
+			break;
+		}
+		}
 		break;
 	case tgt_shared_module:
 	case tgt_dynamic_library:

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -462,7 +462,7 @@ determine_target_build_name(struct workspace *wk,
 	char plain_name[BUF_SIZE_2k])
 {
 	char ver_dll[BUF_SIZE_1k];
-	const char *pref, *suff, *ver_suff = NULL;
+	const char *pref, *suff = 0, *ver_suff = 0;
 
 	*ver_dll = '\0';
 
@@ -472,7 +472,7 @@ determine_target_build_name(struct workspace *wk,
 		if (machine_definitions[tgt->machine]->is_windows) {
 			suff = "exe";
 		} else {
-			suff = NULL;
+			suff = 0;
 		}
 		break;
 	case tgt_static_library:

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -63,6 +63,7 @@ enum build_target_kwargs {
 	bt_kw_win_subsystem, // TODO
 	bt_kw_override_options,
 	bt_kw_link_args,
+	bt_kw_build_subdir,
 
 #define E(lang, s) bt_kw_##lang##s
 #define TOOLCHAIN_ENUM(lang) E(lang, _args), E(lang, _static_args), E(lang, _shared_args), E(lang, _pch),
@@ -579,7 +580,16 @@ create_target(struct workspace *wk,
 	tgt->type = type;
 	tgt->name = name;
 	tgt->cwd = current_project(wk)->cwd;
-	tgt->build_dir = current_project(wk)->build_dir;
+	{
+		if (akw[bt_kw_build_subdir].set) {
+			TSTR(build_dir);
+			path_push(wk, &build_dir, get_cstr(wk, current_project(wk)->build_dir));
+			path_push(wk, &build_dir, get_cstr(wk, akw[bt_kw_build_subdir].val));
+			tgt->build_dir = tstr_into_str(wk, &build_dir);
+		} else {
+			tgt->build_dir = current_project(wk)->build_dir;
+		}
+	}
 	tgt->machine = coerce_machine_kind(wk, &akw[bt_kw_native]);
 	tgt->callstack = vm_callstack(wk);
 	tgt->args = make_obj(wk, obj_dict);
@@ -1155,6 +1165,7 @@ tgt_common(struct workspace *wk, obj *res, enum tgt_type type, enum tgt_type arg
 		[bt_kw_win_subsystem] = { "win_subsystem", obj_string },
 		[bt_kw_override_options] = { "override_options", COMPLEX_TYPE_PRESET(tc_cx_options_dict_or_list) },
 		[bt_kw_link_args] = { "link_args", TYPE_TAG_LISTIFY | obj_string },
+		[bt_kw_build_subdir] = { "build_subdir", obj_string },
 #define E(lang, s, t) [bt_kw_##lang##s] = { #lang #s, t }
 #define TOOLCHAIN_ENUM(lang)                                                                                 \
 	E(lang, _args, TYPE_TAG_LISTIFY | obj_string), E(lang, _static_args, TYPE_TAG_LISTIFY | obj_string), \

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -63,6 +63,7 @@ enum build_target_kwargs {
 	bt_kw_win_subsystem, // TODO
 	bt_kw_override_options,
 	bt_kw_link_args,
+	bt_kw_link_early_args,
 	bt_kw_build_subdir,
 
 #define E(lang, s) bt_kw_##lang##s
@@ -1085,6 +1086,10 @@ create_target(struct workspace *wk,
 		obj_array_extend(wk, tgt->dep_internal.link_args, akw[bt_kw_link_args].val);
 	}
 
+	if (akw[bt_kw_link_early_args].set) {
+		obj_array_extend(wk, tgt->dep_internal.link_early_args, akw[bt_kw_link_early_args].val);
+	}
+
 	if (tgt->flags & build_tgt_generated_include) {
 		const char *private_path = get_cstr(wk, tgt->private_path);
 
@@ -1165,6 +1170,7 @@ tgt_common(struct workspace *wk, obj *res, enum tgt_type type, enum tgt_type arg
 		[bt_kw_win_subsystem] = { "win_subsystem", obj_string },
 		[bt_kw_override_options] = { "override_options", COMPLEX_TYPE_PRESET(tc_cx_options_dict_or_list) },
 		[bt_kw_link_args] = { "link_args", TYPE_TAG_LISTIFY | obj_string },
+		[bt_kw_link_early_args] = { "link_early_args", TYPE_TAG_LISTIFY | obj_string },
 		[bt_kw_build_subdir] = { "build_subdir", obj_string },
 #define E(lang, s, t) [bt_kw_##lang##s] = { #lang #s, t }
 #define TOOLCHAIN_ENUM(lang)                                                                                 \

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -65,6 +65,7 @@ enum build_target_kwargs {
 	bt_kw_link_args,
 	bt_kw_link_early_args,
 	bt_kw_build_subdir,
+	bt_kw_android_exe_type, // TODO
 
 #define E(lang, s) bt_kw_##lang##s
 #define TOOLCHAIN_ENUM(lang) E(lang, _args), E(lang, _static_args), E(lang, _shared_args), E(lang, _pch),
@@ -1172,6 +1173,7 @@ tgt_common(struct workspace *wk, obj *res, enum tgt_type type, enum tgt_type arg
 		[bt_kw_link_args] = { "link_args", TYPE_TAG_LISTIFY | obj_string },
 		[bt_kw_link_early_args] = { "link_early_args", TYPE_TAG_LISTIFY | obj_string },
 		[bt_kw_build_subdir] = { "build_subdir", obj_string },
+		[bt_kw_android_exe_type] = { "android_exe_type", obj_string },
 #define E(lang, s, t) [bt_kw_##lang##s] = { #lang #s, t }
 #define TOOLCHAIN_ENUM(lang)                                                                                 \
 	E(lang, _args, TYPE_TAG_LISTIFY | obj_string), E(lang, _static_args, TYPE_TAG_LISTIFY | obj_string), \

--- a/src/functions/kernel/configure_file.c
+++ b/src/functions/kernel/configure_file.c
@@ -172,34 +172,37 @@ substitute_config_variables(struct workspace *wk, struct configure_file_context 
 			 * - The number of backslashes preceding varstart in the output is
 			 *   equal to the number of backslashes in the input divided by
 			 *   two, rounding down.
-			 * - If mode is cmake and the number of backslashes is even, don't
-			 *   escape the variable, otherwise always escape the variable.
+			 *
+			 * NOTE: This got even more complicated in meson
+			 * c8432df30edea96557db871d67c731537654afbf, now cmake syntax has
+			 * its own escaping rules for meson variables.
 			 */
 
-			uint32_t j, output_backslashes;
+			uint32_t j, output_backslashes = 0;
 			bool output_format_char = false;
 
 			for (j = 1; in->buf[i + j] == '\\'; ++j) {
 			}
 
 			if (configure_file_var_patterns_match(&var_patterns, in, i + j, &match_idx)) {
-				output_backslashes = j / 2;
-
 				if (var_patterns.pats[match_idx].type == configure_file_syntax_mesonvar) {
-					output_format_char = true;
-					i += j;
-				} else {
-					if ((j & 1) != 0) {
-						output_format_char = true;
-						i += j;
-					} else {
+					if (ctx->syntax & configure_file_syntax_cmakedefine) {
+						output_backslashes = j;
 						i += j - 1;
+					} else {
+						output_format_char = true;
+						output_backslashes = j / 2;
+						i += j;
 					}
+				} else if (var_patterns.pats[match_idx].type == configure_file_syntax_cmakevar) {
+					output_backslashes = j;
+					i += j - 1;
+				} else {
+					UNREACHABLE;
 				}
 			} else {
-				i += j - 1;
-
 				output_backslashes = j;
+				i += j - 1;
 			}
 
 			for (j = 0; j < output_backslashes; ++j) {

--- a/src/functions/kernel/configure_file.c
+++ b/src/functions/kernel/configure_file.c
@@ -760,6 +760,7 @@ FUNC_IMPL(kernel, configure_file, tc_file, func_impl_flag_impure)
 		kw_encoding, // TODO: ignored
 		kw_depfile, // TODO: ignored
 		kw_macro_name,
+		kw_build_subdir,
 	};
 	struct args_kw akw[] = {
 		[kw_configuration] = { "configuration", tc_configuration_data | tc_dict },
@@ -777,6 +778,7 @@ FUNC_IMPL(kernel, configure_file, tc_file, func_impl_flag_impure)
 		[kw_encoding] = { "encoding", obj_string },
 		[kw_depfile] = { "depfile", obj_string },
 		[kw_macro_name] = { "macro_name", obj_string },
+		[kw_build_subdir] = { "build_subdir", obj_string },
 		0,
 	};
 
@@ -807,36 +809,34 @@ FUNC_IMPL(kernel, configure_file, tc_file, func_impl_flag_impure)
 	}
 
 	{ /* setup out file */
-		obj subd;
-		if (!perform_output_string_substitutions(
-			    wk, akw[kw_output].node, akw[kw_output].val, input_arr, &subd)) {
-			return false;
-		}
-
-		const char *out = get_cstr(wk, subd);
 		TSTR(out_path);
-
-		if (!path_is_basename(out)) {
-			if (wk->vm.lang_mode == language_external) {
-				vm_error_at(wk,
-					akw[kw_output].node,
-					"config file output '%s' contains path separator",
-					out);
-				return false;
-			}
-
-			TSTR(dir);
-			path_dirname(wk, &dir, out);
-			if (!fs_mkdir_p(wk, dir.buf)) {
-				return false;
-			}
+		path_push(wk, &out_path, workspace_build_dir(wk));
+		if (akw[kw_build_subdir].set) {
+			path_push(wk, &out_path, get_cstr(wk, akw[kw_build_subdir].val));
 		}
 
-		if (!fs_mkdir_p(wk, workspace_build_dir(wk))) {
+		{
+			obj subd;
+			if (!perform_output_string_substitutions(
+				    wk, akw[kw_output].node, akw[kw_output].val, input_arr, &subd)) {
+				return false;
+			}
+			const char *out;
+			out = get_cstr(wk, subd);
+
+			if (!path_is_basename(out) && wk->vm.lang_mode == language_external) {
+				vm_error_at(wk, akw[kw_output].node, "config file output '%s' contains path separator", out);
+				return false;
+			}
+
+			path_push(wk, &out_path, out);
+		}
+
+		TSTR(dir);
+		path_dirname(wk, &dir, out_path.buf);
+		if (!fs_mkdir_p(wk, dir.buf)) {
 			return false;
 		}
-
-		path_join(wk, &out_path, workspace_build_dir(wk), out);
 
 		LOG_I("configuring '%s'", out_path.buf);
 		output_str = tstr_into_str(wk, &out_path);

--- a/src/functions/kernel/custom_target.c
+++ b/src/functions/kernel/custom_target.c
@@ -670,6 +670,7 @@ FUNC_IMPL(kernel, custom_target, tc_custom_target, func_impl_flag_impure)
 		kw_env,
 		kw_feed,
 		kw_console,
+		kw_build_subdir,
 	};
 	struct args_kw akw[] = {
 		[kw_input] = { "input", TYPE_TAG_LISTIFY | tc_coercible_files | tc_generated_list, },
@@ -689,6 +690,7 @@ FUNC_IMPL(kernel, custom_target, tc_custom_target, func_impl_flag_impure)
 		[kw_env] = { "env", tc_coercible_env },
 		[kw_feed] = { "feed", obj_bool },
 		[kw_console] = { "console", obj_bool },
+		[kw_build_subdir] = { "build_subdir", obj_string },
 		0,
 	};
 
@@ -710,6 +712,12 @@ FUNC_IMPL(kernel, custom_target, tc_custom_target, func_impl_flag_impure)
 		name = v;
 	}
 
+	TSTR(output_dir);
+	path_push(wk, &output_dir, get_cstr(wk, current_project(wk)->build_dir));
+	if (akw[kw_build_subdir].set) {
+		path_push(wk, &output_dir, get_cstr(wk, akw[kw_build_subdir].val));
+	}
+
 	struct make_custom_target_opts opts = {
 		.name = name,
 		.input_node = akw[kw_input].node,
@@ -717,7 +725,7 @@ FUNC_IMPL(kernel, custom_target, tc_custom_target, func_impl_flag_impure)
 		.command_node = akw[kw_command].node,
 		.input_orig = akw[kw_input].val,
 		.output_orig = akw[kw_output].val,
-		.output_dir = get_cstr(wk, current_project(wk)->build_dir),
+		.output_dir = output_dir.buf,
 		.command_orig = akw[kw_command].val,
 		.depfile_orig = akw[kw_depfile].val,
 		.capture = akw[kw_capture].set && get_obj_bool(wk, akw[kw_capture].val),

--- a/src/functions/kernel/dependency.c
+++ b/src/functions/kernel/dependency.c
@@ -1707,6 +1707,10 @@ build_dep_init(struct workspace *wk, struct build_dep *dep)
 		dep->link_args = make_obj(wk, obj_array);
 	}
 
+	if (!dep->link_early_args) {
+		dep->link_early_args = make_obj(wk, obj_array);
+	}
+
 	if (!dep->compile_args) {
 		dep->compile_args = make_obj(wk, obj_array);
 	}
@@ -1758,6 +1762,10 @@ build_dep_merge(struct workspace *wk,
 
 	if (src->link_args) {
 		obj_array_extend(wk, dest->link_args, src->link_args);
+	}
+
+	if (src->link_early_args) {
+		obj_array_extend(wk, dest->link_early_args, src->link_early_args);
 	}
 
 	if (src->frameworks) {
@@ -1832,6 +1840,37 @@ is_any_str(const struct str *s, const struct str *strs, uint32_t len)
 	return false;
 }
 
+static obj
+dedup_link_args(struct workspace *wk, obj link_args)
+{
+	obj arg, new_args = make_obj(wk, obj_array);
+	obj prev = 0;
+	const struct str *prev_s = 0;
+
+	obj_array_for(wk, link_args, arg) {
+		bool add = true;
+		const struct str *s = get_str(wk, arg);
+		if (str_eql(s, &STR("-pthread"))) {
+			if (obj_array_in(wk, new_args, arg)) {
+				add = false;
+			}
+		} else if (prev_s && str_eql(prev_s, &STR("-framework"))) {
+			if (obj_array_pair_in(wk, new_args, prev, arg)) {
+				obj_array_pop(wk, new_args);
+				add = false;
+			}
+		}
+
+		if (add) {
+			obj_array_push(wk, new_args, arg);
+		}
+
+		prev = arg;
+		prev_s = s;
+	}
+	return new_args;
+}
+
 static void
 dedup_build_dep(struct workspace *wk, struct build_dep *dep)
 {
@@ -1850,34 +1889,8 @@ dedup_build_dep(struct workspace *wk, struct build_dep *dep)
 	obj_array_dedup_in_place(wk, &dep->sources);
 	obj_array_dedup_in_place(wk, &dep->objects);
 
-	{
-		obj arg, new_args = make_obj(wk, obj_array);
-		obj prev = 0;
-		const struct str *prev_s = 0;
-
-		obj_array_for(wk, dep->link_args, arg) {
-			bool add = true;
-			const struct str *s = get_str(wk, arg);
-			if (str_eql(s, &STR("-pthread"))) {
-				if (obj_array_in(wk, new_args, arg)) {
-					add = false;
-				}
-			} else if (prev_s && str_eql(prev_s, &STR("-framework"))) {
-				if (obj_array_pair_in(wk, new_args, prev, arg)) {
-					obj_array_pop(wk, new_args);
-					add = false;
-				}
-			}
-
-			if (add) {
-				obj_array_push(wk, new_args, arg);
-			}
-
-			prev = arg;
-			prev_s = s;
-		}
-		dep->link_args = new_args;
-	}
+	dep->link_args = dedup_link_args(wk, dep->link_args);
+	dep->link_early_args = dedup_link_args(wk, dep->link_early_args);
 
 	{
 		obj arg, new_args = make_obj(wk, obj_array);
@@ -2173,6 +2186,10 @@ dependency_create(struct workspace *wk,
 
 	if (raw->link_args && IS_INCLUDED(link_args)) {
 		obj_array_extend_nodup(wk, dep->link_args, raw->link_args);
+	}
+
+	if (raw->link_early_args && IS_INCLUDED(link_args)) {
+		obj_array_extend_nodup(wk, dep->link_early_args, raw->link_early_args);
 	}
 
 	if (raw->compile_args && IS_INCLUDED(compile_args)) {

--- a/src/functions/kernel/install.c
+++ b/src/functions/kernel/install.c
@@ -147,11 +147,13 @@ FUNC_IMPL(kernel, install_man, 0, func_impl_flag_impure)
 		kw_install_dir,
 		kw_install_mode,
 		kw_locale,
+		kw_install_tag,
 	};
 	struct args_kw akw[] = {
 		[kw_install_dir] = { "install_dir", obj_string },
 		[kw_install_mode] = { "install_mode", tc_install_mode_kw },
 		[kw_locale] = { "locale", obj_string },
+		[kw_install_tag] = { "install_tag", tc_string }, // TODO
 		0,
 	};
 	if (!pop_args(wk, an, akw)) {
@@ -378,6 +380,7 @@ FUNC_IMPL(kernel, install_headers, 0, func_impl_flag_impure)
 		kw_subdir,
 		kw_preserve_path,
 		kw_follow_symlinks,
+		kw_install_tag,
 	};
 	struct args_kw akw[] = {
 		[kw_install_dir] = { "install_dir", obj_string },
@@ -385,6 +388,7 @@ FUNC_IMPL(kernel, install_headers, 0, func_impl_flag_impure)
 		[kw_subdir] = { "subdir", obj_string },
 		[kw_preserve_path] = { "preserve_path", obj_bool },
 		[kw_follow_symlinks] = { "follow_symlinks", obj_bool },
+		[kw_install_tag] = { "install_tag", tc_string }, // TODO
 		0,
 	};
 	if (!pop_args(wk, an, akw)) {

--- a/src/functions/kernel/options.c
+++ b/src/functions/kernel/options.c
@@ -251,6 +251,11 @@ FUNC_IMPL(kernel, get_option, tc_string | tc_number | tc_bool | tc_feature_opt |
 	const struct str *opt_name = get_str(wk, an[0].val);
 	obj opt;
 	if (!get_option(wk, current_project(wk), opt_name, &opt)) {
+		if (wk->vm.in_analyzer && !current_project(wk)) {
+			*res = make_typeinfo(wk, tc_string | tc_number | tc_bool | tc_feature_opt | tc_array);
+			return true;
+		}
+
 		vm_error_at(wk, an[0].node, "undefined option");
 		return false;
 	}

--- a/src/functions/kernel/options.c
+++ b/src/functions/kernel/options.c
@@ -223,6 +223,23 @@ FUNC_IMPL(kernel, option, 0, true)
 	return true;
 }
 
+static bool
+rewrite_option_value(struct workspace *wk, const struct obj_option *o, const struct str *name, obj *res)
+{
+	if (str_eql(name, &STR("b_sanitize"))) {
+		if (!get_obj_array(wk, o->val)->len) {
+			*res = make_str(wk, "none");
+		} else {
+			obj sorted;
+			obj_array_sort(wk, 0, o->val, obj_array_sort_by_str, &sorted);
+			obj_array_join(wk, false, sorted, make_str(wk, ","), res);
+		}
+		return true;
+	}
+
+	return false;
+}
+
 FUNC_IMPL(kernel, get_option, tc_string | tc_number | tc_bool | tc_feature_opt | tc_array)
 {
 	struct args_norm an[] = { { obj_string }, ARG_TYPE_NULL };
@@ -231,13 +248,18 @@ FUNC_IMPL(kernel, get_option, tc_string | tc_number | tc_bool | tc_feature_opt |
 		return false;
 	}
 
+	const struct str *opt_name = get_str(wk, an[0].val);
 	obj opt;
-	if (!get_option(wk, current_project(wk), get_str(wk, an[0].val), &opt)) {
+	if (!get_option(wk, current_project(wk), opt_name, &opt)) {
 		vm_error_at(wk, an[0].node, "undefined option");
 		return false;
 	}
 
 	struct obj_option *o = get_obj_option(wk, opt);
+
+	if (rewrite_option_value(wk, o, opt_name, res)) {
+		return true;
+	}
 
 	if (wk->vm.in_analyzer) {
 		type_tag t = 0;

--- a/src/functions/kernel/options.c
+++ b/src/functions/kernel/options.c
@@ -29,7 +29,8 @@ build_option_type_from_s(struct workspace *wk, uint32_t node, uint32_t name, enu
 
 	enum build_option_type type;
 	for (type = 0; type < build_option_type_count; ++type) {
-		if (type == op_shell_array && !initializing_builtin_options) {
+		if (type == op_shell_array
+			&& initializing_builtin_options_state == initializing_builtin_options_state_none) {
 			continue;
 		}
 
@@ -90,7 +91,7 @@ FUNC_IMPL(kernel, option, 0, true)
 		[kw_per_machine] = { 0 },
 		0 };
 
-	if (initializing_builtin_options) {
+	if (initializing_builtin_options_state != initializing_builtin_options_state_none) {
 		akw[kw_kind] = (struct args_kw){ "kind", tc_string };
 		akw[kw_per_machine] = (struct args_kw){ "per_machine", tc_bool };
 	}

--- a/src/functions/meson.c
+++ b/src/functions/meson.c
@@ -13,6 +13,7 @@
 #include "buf_size.h"
 #include "coerce.h"
 #include "error.h"
+#include "functions/external_program.h"
 #include "functions/kernel.h"
 #include "functions/kernel/dependency.h"
 #include "functions/meson.h"
@@ -317,35 +318,27 @@ FUNC_IMPL(meson, override_find_program, 0, func_impl_flag_impure)
 	enum machine_kind machine = coerce_machine_kind(wk, &akw[kw_native]);
 
 	obj override;
-
-	switch (get_obj_type(wk, an[1].val)) {
-	case obj_array:
+	enum obj_type t = get_obj_type(wk, an[1].val);
+	if (t == obj_external_program || t == obj_python_installation) {
+		override = an[1].val;
+	} else {
 		override = make_obj(wk, obj_external_program);
 		struct obj_external_program *ep = get_obj_external_program(wk, override);
-		ep->cmd_array = an[1].val;
 		ep->found = true;
 
 		struct project *proj = current_project(wk);
-		if (proj && !proj->cfg.no_version) {
-			ep->guessed_ver = true;
-			ep->ver = proj->cfg.version;
-		}
-		break;
-	case obj_build_target:
-	case obj_custom_target:
-	case obj_file:
-		override = make_obj(wk, obj_array);
-		obj_array_push(wk, override, an[1].val);
+		ep->ver = (proj && !proj->cfg.no_version) ? proj->cfg.version : make_str(wk, "unknown");
 
-		obj ver = 0;
-		if (!current_project(wk)->cfg.no_version) {
-			ver = current_project(wk)->cfg.version;
+		switch (t) {
+		case obj_array: ep->impl.cmd_array = an[1].val; break;
+		case obj_build_target:
+		case obj_custom_target: ep->impl.build_target = an[1].val; break;
+		case obj_file:
+			ep->impl.cmd_array = make_obj(wk, obj_array);
+			obj_array_push(wk, ep->impl.cmd_array, *get_obj_file(wk, an[1].val));
+			break;
+		default: UNREACHABLE;
 		}
-		obj_array_push(wk, override, ver);
-		break;
-	case obj_external_program:
-	case obj_python_installation: override = an[1].val; break;
-	default: UNREACHABLE;
 	}
 
 	obj_dict_set(wk, wk->find_program_overrides[machine], an[0].val, override);
@@ -384,7 +377,8 @@ process_script_commandline(struct workspace *wk, struct process_script_commandli
 				return false;
 			}
 
-			obj_array_extend(wk, ctx->arr, get_obj_external_program(wk, found_prog)->cmd_array);
+			obj cmd_array = obj_external_program_cmd_array(wk, get_obj_external_program(wk, found_prog), 0);
+			obj_array_extend(wk, ctx->arr, cmd_array);
 		}
 		break;
 	}

--- a/src/functions/meson.c
+++ b/src/functions/meson.c
@@ -324,6 +324,12 @@ FUNC_IMPL(meson, override_find_program, 0, func_impl_flag_impure)
 		struct obj_external_program *ep = get_obj_external_program(wk, override);
 		ep->cmd_array = an[1].val;
 		ep->found = true;
+
+		struct project *proj = current_project(wk);
+		if (proj && !proj->cfg.no_version) {
+			ep->guessed_ver = true;
+			ep->ver = proj->cfg.version;
+		}
 		break;
 	case obj_build_target:
 	case obj_custom_target:

--- a/src/functions/meson.c
+++ b/src/functions/meson.c
@@ -562,6 +562,26 @@ FUNC_IMPL(meson, get_cross_property, tc_any, func_impl_flag_impure)
 	return meson_get_property(wk, wk->machine_properties[machine_kind_host], an[0].val, an[1].val, res);
 }
 
+FUNC_IMPL(meson, has_external_property, tc_any, func_impl_flag_impure)
+{
+	struct args_norm an[] = { { obj_string }, ARG_TYPE_NULL };
+	enum kwargs {
+		kw_native,
+	};
+	struct args_kw akw[] = {
+		[kw_native] = { "native", obj_bool },
+		0,
+	};
+	if (!pop_args(wk, an, akw)) {
+		return false;
+	}
+
+	obj dict = wk->machine_properties[coerce_machine_kind(wk, &akw[kw_native])];
+	obj _;
+	*res = make_obj_bool(wk, obj_dict_index(wk, dict, an[0].val, &_));
+	return true;
+}
+
 FUNC_IMPL(meson, get_external_property, tc_any, func_impl_flag_impure)
 {
 	struct args_norm an[] = { { obj_string }, { tc_any, .optional = true }, ARG_TYPE_NULL };
@@ -894,6 +914,7 @@ FUNC_REGISTER(meson)
 	FUNC_IMPL_REGISTER_ALIAS(meson, global_build_root, build_root);
 	FUNC_IMPL_REGISTER(meson, global_source_root);
 	FUNC_IMPL_REGISTER_ALIAS(meson, global_source_root, source_root);
+	FUNC_IMPL_REGISTER(meson, has_external_property);
 	FUNC_IMPL_REGISTER(meson, is_cross_build);
 	FUNC_IMPL_REGISTER(meson, is_subproject);
 	FUNC_IMPL_REGISTER(meson, is_unity);

--- a/src/functions/modules/fs.c
+++ b/src/functions/modules/fs.c
@@ -285,6 +285,30 @@ FUNC_IMPL(module_fs, stem, tc_string, .desc = "Get the basename of a path with i
 	return true;
 }
 
+FUNC_IMPL(module_fs, suffix, tc_string, .desc = "The last dot-separated portion of the final component, if any" )
+{
+	struct args_norm an[] = { { tc_coercible_files }, ARG_TYPE_NULL };
+	if (!pop_args(wk, an, NULL)) {
+		return false;
+	}
+
+	TSTR(path);
+	if (!fix_file_path(wk, an[0].node, an[0].val, fix_file_path_noexpanduser, &path)) {
+		return false;
+	}
+
+	TSTR(basename);
+	path_basename(wk, &basename, path.buf);
+
+	const char *sep = strrchr(basename.buf, '.');
+	if (sep) {
+		*res = make_str(wk, sep);
+	} else {
+		*res = make_str(wk, "");
+	}
+	return true;
+}
+
 FUNC_IMPL(module_fs, as_posix, tc_string, .desc = "Convert backslashes to `/`" )
 {
 	struct args_norm an[] = { { tc_string }, ARG_TYPE_NULL };
@@ -957,6 +981,7 @@ FUNC_REGISTER(module_fs)
 	FUNC_IMPL_REGISTER(module_fs, replace_suffix);
 	FUNC_IMPL_REGISTER(module_fs, size);
 	FUNC_IMPL_REGISTER(module_fs, stem);
+	FUNC_IMPL_REGISTER(module_fs, suffix);
 
 	// non-standard muon extensions
 	if (lang_mode == language_internal) {

--- a/src/functions/modules/pkgconfig.c
+++ b/src/functions/modules/pkgconfig.c
@@ -28,7 +28,7 @@ enum pkgconf_visibility {
 
 struct pkgconf_file {
 	// strings
-	obj name, description, url, version;
+	obj name, description, url, version, license;
 
 	// arrays of string
 	obj conflicts;
@@ -715,6 +715,10 @@ module_pkgconf_write(struct workspace *wk, const char *path, struct pkgconf_file
 		fprintf(f, "URL: %s\n", get_cstr(wk, pc->url));
 	}
 
+	if (pc->license) {
+		fprintf(f, "License: %s\n", get_cstr(wk, pc->license));
+	}
+
 	fprintf(f, "Version: %s\n", get_cstr(wk, pc->version));
 
 	if (get_obj_array(wk, pc->reqs[pkgconf_visibility_pub])->len) {
@@ -781,6 +785,7 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 		kw_version,
 		kw_dataonly,
 		kw_conflicts,
+		kw_license
 	};
 	const type_tag tc_library = tc_string | tc_file | tc_build_target | tc_dependency | tc_custom_target
 				    | tc_both_libs,
@@ -807,6 +812,7 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 		[kw_version] = { "version", obj_string },
 		[kw_dataonly] = { "dataonly", obj_bool },
 		[kw_conflicts] = { "conflicts", TYPE_TAG_LISTIFY | obj_string },
+		[kw_license] = { "license", obj_string },
 		0,
 	};
 	if (!pop_args(wk, an, akw)) {
@@ -863,6 +869,8 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 	} else {
 		pc.version = current_project(wk)->cfg.version;
 	}
+
+	pc.license = akw[kw_license].val;
 
 	/* cflags include dirs */
 	if (akw[kw_subdirs].set) {

--- a/src/functions/modules/pkgconfig.c
+++ b/src/functions/modules/pkgconfig.c
@@ -32,9 +32,9 @@ struct pkgconf_file {
 	obj name, description, url, version;
 
 	// arrays of string
-	obj cflags, conflicts;
+	obj conflicts;
 	obj builtin_dir_variables, variables;
-	obj reqs[2], libs[2];
+	obj reqs[2], libs[2], cflags[2];
 	obj exclude;
 	bool libs_contains_internal[2];
 
@@ -326,7 +326,7 @@ module_pkgconf_process_libs_iter(struct workspace *wk, void *_ctx, obj val)
 			// dependency semantics if this is a sub dependency of
 			// a partial dep with compile_args: false
 			if (dep->dep.compile_args) {
-				obj_array_extend(wk, ctx->pc->cflags, dep->dep.compile_args);
+				obj_array_extend(wk, ctx->pc->cflags[ctx->vis], dep->dep.compile_args);
 			}
 
 			if (dep->dep.raw.link_with) {
@@ -713,8 +713,13 @@ module_pkgconf_write(struct workspace *wk, const char *path, struct pkgconf_file
 		fprintf(f, "Libs.private: %s\n", get_cstr(wk, str));
 	}
 
-	if (!pc->dataonly && get_obj_array(wk, pc->cflags)->len) {
-		fprintf(f, "Cflags: %s\n", get_cstr(wk, join_args_pkgconf(wk, pc->cflags)));
+	if (!pc->dataonly) {
+		if (get_obj_array(wk, pc->cflags[pkgconf_visibility_pub])->len) {
+			fprintf(f, "Cflags: %s\n", get_cstr(wk, join_args_pkgconf(wk, pc->cflags[pkgconf_visibility_pub])));
+		}
+		if (get_obj_array(wk, pc->cflags[pkgconf_visibility_priv])->len) {
+			fprintf(f, "Cflags.private: %s\n", get_cstr(wk, join_args_pkgconf(wk, pc->cflags[pkgconf_visibility_priv])));
+		}
 	}
 
 	if (!fs_fclose(f)) {
@@ -744,6 +749,7 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 		kw_unescaped_variables,
 		kw_uninstalled_variables, // TODO
 		kw_unescaped_uninstalled_variables, // TODO
+		kw_cflags_private,
 		kw_version,
 		kw_dataonly,
 		kw_conflicts,
@@ -769,6 +775,7 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 		[kw_uninstalled_variables] = { "uninstalled_variables", tc_string | tc_array | tc_dict },
 		[kw_unescaped_uninstalled_variables]
 		= { "unescaped_uninstalled_variables", tc_string | tc_array | tc_dict },
+		[kw_cflags_private] = { "cflags_private", TYPE_TAG_LISTIFY | tc_string },
 		[kw_version] = { "version", obj_string },
 		[kw_dataonly] = { "dataonly", obj_bool },
 		[kw_conflicts] = { "conflicts", TYPE_TAG_LISTIFY | obj_string },
@@ -792,7 +799,8 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 		pc.libs[i] = make_obj(wk, obj_array);
 		pc.reqs[i] = make_obj(wk, obj_array);
 	}
-	pc.cflags = make_obj(wk, obj_array);
+	pc.cflags[pkgconf_visibility_pub] = make_obj(wk, obj_array);
+	pc.cflags[pkgconf_visibility_priv] = make_obj(wk, obj_array);
 	pc.variables = make_obj(wk, obj_array);
 	pc.builtin_dir_variables = make_obj(wk, obj_array);
 	pc.exclude = make_obj(wk, obj_array);
@@ -834,7 +842,7 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 			return false;
 		}
 	} else {
-		obj_array_push(wk, pc.cflags, make_str(wk, "-I${includedir}"));
+		obj_array_push(wk, pc.cflags[pkgconf_visibility_pub], make_str(wk, "-I${includedir}"));
 	}
 
 	if (mainlib) {
@@ -891,7 +899,11 @@ FUNC_IMPL(module_pkgconfig, generate, tc_file, func_impl_flag_impure)
 	}
 
 	if (akw[kw_extra_cflags].set) {
-		obj_array_extend(wk, pc.cflags, akw[kw_extra_cflags].val);
+		obj_array_extend(wk, pc.cflags[pkgconf_visibility_pub], akw[kw_extra_cflags].val);
+	}
+
+	if (akw[kw_cflags_private].set) {
+		obj_array_extend(wk, pc.cflags[pkgconf_visibility_priv], akw[kw_cflags_private].val);
 	}
 
 	{ // variables

--- a/src/functions/modules/pkgconfig.c
+++ b/src/functions/modules/pkgconfig.c
@@ -6,8 +6,6 @@
 
 #include "compat.h"
 
-#include <string.h>
-
 #include "args.h"
 #include "buf_size.h"
 #include "error.h"
@@ -16,6 +14,7 @@
 #include "functions/custom_target.h"
 #include "functions/file.h"
 #include "install.h"
+#include "lang/object_iterators.h"
 #include "lang/typecheck.h"
 #include "options.h"
 #include "platform/assert.h"
@@ -162,8 +161,37 @@ module_pkgconf_process_reqs_iter(struct workspace *wk, void *_ctx, obj val)
 			return ir_cont;
 		}
 
+		if (dep->type == dependency_type_declared && dep->dep.raw.link_with) {
+			obj v;
+			bool all_valid = true;
+			obj_array_for(wk, dep->dep.raw.link_with, v) {
+				switch (get_obj_type(wk, v)) {
+				case obj_both_libs: v = decay_both_libs(wk, v);
+				/* fallthrough */
+				case obj_build_target: {
+					struct obj_build_target *tgt = get_obj_build_target(wk, v);
+					if (tgt->generated_pc) {
+						obj_array_push(wk, ctx->dest, tgt->generated_pc);
+					} else {
+						all_valid = false;
+					}
+					break;
+				}
+				default: all_valid = false; break;
+				}
+
+				if (!all_valid) {
+					break;
+				}
+			}
+
+			if (all_valid) {
+				return ir_cont;
+			}
+		}
+
 		if (dep->type != dependency_type_pkgconf) {
-			vm_error_at(wk, ctx->err_node, "dependency not from pkgconf");
+			vm_error_at(wk, ctx->err_node, "dependency not from pkgconfig");
 			return ir_err;
 		}
 

--- a/src/functions/modules/python.c
+++ b/src/functions/modules/python.c
@@ -269,9 +269,9 @@ FUNC_IMPL(python_installation, get_path, tc_string, func_impl_flag_impure)
 	return true;
 }
 
-FUNC_IMPL(python_installation, get_variable, tc_string, func_impl_flag_impure)
+FUNC_IMPL(python_installation, get_variable, tc_any, func_impl_flag_impure)
 {
-	struct args_norm an[] = { { obj_string }, { obj_string, .optional = true }, ARG_TYPE_NULL };
+	struct args_norm an[] = { { obj_string }, { tc_any, .optional = true }, ARG_TYPE_NULL };
 	if (!pop_args(wk, an, NULL)) {
 		return false;
 	}

--- a/src/functions/modules/python.c
+++ b/src/functions/modules/python.c
@@ -119,8 +119,8 @@ build_python_installation(struct workspace *wk, obj self, obj *res, struct tstr 
 	python->prog = make_obj(wk, obj_external_program);
 	struct obj_external_program *ep = get_obj_external_program(wk, python->prog);
 	ep->found = found;
-	ep->cmd_array = make_obj(wk, obj_array);
-	obj_array_push(wk, ep->cmd_array, tstr_into_str(wk, &cmd_path));
+	ep->impl.cmd_array = make_obj(wk, obj_array);
+	obj_array_push(wk, ep->impl.cmd_array, tstr_into_str(wk, &cmd_path));
 
 	if (found && !introspect_python_interpreter(wk, cmd_path.buf, python)) {
 		vm_error(wk, "failed to introspect python");
@@ -241,8 +241,8 @@ FUNC_IMPL(module_python3, find_python, tc_external_program, func_impl_flag_impur
 	*res = make_obj(wk, obj_external_program);
 	struct obj_external_program *ep = get_obj_external_program(wk, *res);
 	ep->found = true;
-	ep->cmd_array = make_obj(wk, obj_array);
-	obj_array_push(wk, ep->cmd_array, tstr_into_str(wk, &cmd_path));
+	ep->impl.cmd_array = make_obj(wk, obj_array);
+	obj_array_push(wk, ep->impl.cmd_array, tstr_into_str(wk, &cmd_path));
 
 	return true;
 }
@@ -520,14 +520,15 @@ FUNC_IMPL(python_installation, path, tc_string, func_impl_flag_impure)
 
 	struct obj_python_installation *py = get_obj_python_installation(wk, self);
 	struct obj_external_program *ep = get_obj_external_program(wk, py->prog);
-	if (get_obj_array(wk, ep->cmd_array)->len > 1) {
+	obj cmd_arr = ep->impl.cmd_array;
+	if (get_obj_array(wk, cmd_arr)->len > 1) {
 		vm_error(wk,
 			"cannot return the full_path() of an external program with multiple elements (have: %o)\n",
-			ep->cmd_array);
+			ep->impl.cmd_array);
 		return false;
 	}
 
-	*res = obj_array_index(wk, get_obj_external_program(wk, self)->cmd_array, 0);
+	*res = obj_array_index(wk, cmd_arr, 0);
 	return true;
 }
 

--- a/src/functions/source_set.c
+++ b/src/functions/source_set.c
@@ -83,7 +83,7 @@ FUNC_IMPL(source_set, add, 0, func_impl_flag_impure)
 	struct args_kw akw[] = {
 		[kw_when] = { "when", TYPE_TAG_LISTIFY | tc_string | tc_dependency },
 		[kw_if_true] = { "if_true", TYPE_TAG_LISTIFY | tc_ss_sources | tc_dependency },
-		[kw_if_false] = { "if_false", TYPE_TAG_LISTIFY | tc_ss_sources },
+		[kw_if_false] = { "if_false", TYPE_TAG_LISTIFY | tc_ss_sources | tc_dependency },
 		0,
 	};
 

--- a/src/functions/string.c
+++ b/src/functions/string.c
@@ -311,13 +311,13 @@ version_compare_list(struct workspace *wk, const struct str *ver, obj cmp_arr)
 
 FUNC_IMPL(string, version_compare, tc_bool)
 {
-	struct args_norm an[] = { { obj_string }, ARG_TYPE_NULL };
+	struct args_norm an[] = { { TYPE_TAG_GLOB | tc_string }, ARG_TYPE_NULL };
 
 	if (!pop_args(wk, an, NULL)) {
 		return false;
 	}
 
-	bool matches = version_compare(get_str(wk, self), get_str(wk, an[0].val));
+	bool matches = version_compare_list(wk, get_str(wk, self), an[0].val);
 
 	*res = make_obj_bool(wk, matches);
 	return true;

--- a/src/functions/string.c
+++ b/src/functions/string.c
@@ -115,12 +115,12 @@ string_format(struct workspace *wk, uint32_t err_node, obj str, obj *res, void *
 				}
 
 				reading_id = false;
-			} else if (!is_valid_inside_of_identifier(ss_in->s[i])) {
+			} else if (!is_valid_inside_of_identifier(ss_in->s[i], 0)) {
 				str_appn(wk, res, key.s - 1, key.len + 1);
 				text.s = &ss_in->s[i];
 				reading_id = false;
 			}
-		} else if (ss_in->s[i] == '@' && is_valid_inside_of_identifier(ss_in->s[i + 1])) {
+		} else if (ss_in->s[i] == '@' && is_valid_inside_of_identifier(ss_in->s[i + 1], 0)) {
 			text.len = &ss_in->s[i] - text.s;
 			str_appn(wk, res, text.s, text.len);
 			text.s = &ss_in->s[i];

--- a/src/lang/docs.c
+++ b/src/lang/docs.c
@@ -32,7 +32,7 @@ static struct {
 static const bool dump_docs_warn_missing = false;
 
 struct meson_doc_entry_common {
-	const char *name, *description, *type;
+	const char *name, *description;
 };
 
 struct meson_doc_entry_func {
@@ -43,7 +43,6 @@ struct meson_doc_entry_func {
 
 struct meson_doc_entry_arg {
 	struct meson_doc_entry_common common;
-	bool optional, glob;
 };
 
 #ifdef HAVE_MESON_DOCS_H

--- a/src/lang/eval.c
+++ b/src/lang/eval.c
@@ -119,6 +119,8 @@ eval(struct workspace *wk, const struct source *src, const struct eval_opts *opt
 			  vm_compile_mode_language_extended :
 			  0;
 
+	compile_mode |= opts->compile_flags;
+
 	if (opts->mode & eval_mode_repl) {
 		compile_mode |= vm_compile_mode_expr;
 	}

--- a/src/lang/lexer.c
+++ b/src/lang/lexer.c
@@ -108,9 +108,17 @@ token_to_s(struct workspace *wk, struct token *token)
 ******************************************************************************/
 
 bool
-is_valid_start_of_identifier(const char c)
+is_valid_start_of_identifier(const char c, const char *extra)
 {
-	return c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
+	if (c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')) {
+		return true;
+	}
+
+	if (extra && strchr(extra, c)) {
+		return true;
+	}
+
+	return false;
 }
 
 bool
@@ -126,9 +134,9 @@ is_hex_digit(const char c)
 }
 
 bool
-is_valid_inside_of_identifier(const char c)
+is_valid_inside_of_identifier(const char c, const char *extra)
 {
-	return is_valid_start_of_identifier(c) || is_digit(c);
+	return is_valid_start_of_identifier(c, extra) || is_digit(c);
 }
 
 static bool
@@ -882,11 +890,11 @@ restart:
 			lex_copy_str(lexer, token, start, lexer->i);
 		}
 		return;
-	} else if (is_valid_start_of_identifier(lexer->src[lexer->i])) {
+	} else if (is_valid_start_of_identifier(lexer->src[lexer->i], lexer->extra_identifier_chars)) {
 		start = lexer->i;
 		struct str str = { &lexer->src[lexer->i] };
 
-		while (is_valid_inside_of_identifier(lexer->src[lexer->i])) {
+		while (is_valid_inside_of_identifier(lexer->src[lexer->i], lexer->extra_identifier_chars)) {
 			lex_advance(lexer);
 			++str.len;
 		}
@@ -1105,10 +1113,11 @@ restart:
 
 		token->type = token_type_string;
 
-		if (is_valid_start_of_identifier(lexer->src[start])) {
+		if (is_valid_start_of_identifier(lexer->src[start], lexer->extra_identifier_chars)) {
 			uint32_t i;
 			for (i = 1; i < str.len; ++i) {
-				if (!is_valid_inside_of_identifier(lexer->src[start + i])) {
+				if (!is_valid_inside_of_identifier(
+					    lexer->src[start + i], lexer->extra_identifier_chars)) {
 					break;
 				}
 			}

--- a/src/lang/lexer.c
+++ b/src/lang/lexer.c
@@ -725,7 +725,11 @@ lexer_push_pop_enclosed_state(struct lexer *lexer, enum token_type type)
 			stack_pop(&lexer->stack, lexer->enclosed_state);
 		}
 	} else {
-		stack_push(&lexer->stack, lexer->enclosed_state, enclosed_state);
+		if (!stack_try_push(&lexer->stack, lexer->enclosed_state, enclosed_state)) {
+			struct source_location loc = { .off = lexer->i, .len = 1 };
+			error_message(lexer->wk, lexer->source, loc, log_error, 0, "lexer stack overflow trying to push enclosed state");
+			error_unrecoverable("cannot continue");
+		}
 	}
 }
 

--- a/src/lang/object.c
+++ b/src/lang/object.c
@@ -2408,6 +2408,7 @@ obj_inspect_dep(struct workspace *wk, const char *pre, const struct build_dep *d
 	obj_lprintf(wk, log_info, "%slink_with: %o\n", pre, dep->link_with);
 	obj_lprintf(wk, log_info, "%slink_with_not_found: %o\n", pre, dep->link_with_not_found);
 	obj_lprintf(wk, log_info, "%slink_args: %o\n", pre, dep->link_args);
+	obj_lprintf(wk, log_info, "%slink_early_args: %o\n", pre, dep->link_early_args);
 	obj_lprintf(wk, log_info, "%scompile_args: %o\n", pre, dep->compile_args);
 	obj_lprintf(wk, log_info, "%sinclude_directories: %o\n", pre, dep->include_directories);
 	obj_lprintf(wk, log_info, "%ssources: %o\n", pre, dep->sources);

--- a/src/lang/object.c
+++ b/src/lang/object.c
@@ -7,12 +7,12 @@
 
 #include "compat.h"
 
-#include "lang/vm.h"
 #include <inttypes.h>
 #include <stdlib.h>
 
 #include "buf_size.h"
 #include "error.h"
+#include "functions/external_program.h"
 #include "lang/func_lookup.h"
 #include "lang/object.h"
 #include "lang/object_iterators.h"
@@ -2057,10 +2057,9 @@ obj_to_s_opts(struct workspace *wk, obj o, struct tstr *sb, struct obj_to_s_opts
 		struct obj_external_program *prog = get_obj_external_program(wk, o);
 		tstr_pushf(wk, sb, "<%s found: %s", obj_type_to_s(t), prog->found ? "true" : "false");
 
-		if (prog->found) {
-			tstr_pushs(wk, sb, ", cmd_array: ");
-			obj_to_s_opts(wk, prog->cmd_array, sb, opts);
-		}
+		obj cmd_arr = obj_external_program_cmd_array(wk, prog, 0);
+		tstr_pushs(wk, sb, ", cmd_array: ");
+		obj_to_s_opts(wk, cmd_arr, sb, opts);
 
 		tstr_pushs(wk, sb, ">");
 		break;

--- a/src/lang/parser.c
+++ b/src/lang/parser.c
@@ -733,8 +733,11 @@ parse_fstring(struct parser *p, bool assignment_allowed)
 	res = n = 0;
 
 	for (i = 0; i < fstr->len;) {
-		if (fstr->s[i] == '@' && is_valid_start_of_identifier(fstr->s[i + 1])) {
-			for (j = i + 1; j < fstr->len && is_valid_inside_of_identifier(fstr->s[j]); ++j) {
+		if (fstr->s[i] == '@'
+			&& is_valid_start_of_identifier(fstr->s[i + 1], p->lexer.extra_identifier_chars)) {
+			for (j = i + 1; j < fstr->len
+					&& is_valid_inside_of_identifier(fstr->s[j], p->lexer.extra_identifier_chars);
+				++j) {
 			}
 
 			if (fstr->s[j] == '@' && (identifier.len = j - i - 1) > 0) {
@@ -1343,6 +1346,10 @@ parser_init(struct workspace *wk,
 		lexer_mode |= lexer_mode_fmt;
 	}
 	lexer_init(&p->lexer, p->wk, p->src, lexer_mode);
+
+	if (p->mode & vm_compile_mode_tilde_identifier) {
+		p->lexer.extra_identifier_chars = "~";
+	}
 }
 
 static struct node *

--- a/src/lang/parser.c
+++ b/src/lang/parser.c
@@ -721,6 +721,11 @@ parse_fstring(struct parser *p, bool assignment_allowed)
 {
 	uint32_t i, j;
 	const struct str *fstr = get_str(p->wk, p->previous.data.str);
+
+	if (!fstr->len) {
+		return make_node_t(p, node_type_string);
+	}
+
 	struct str str = { fstr->s }, identifier;
 
 	struct node *n, *res, *lhs = 0, *rhs = 0, *prev_rhs;

--- a/src/lang/typecheck.c
+++ b/src/lang/typecheck.c
@@ -6,6 +6,7 @@
 #include <inttypes.h>
 
 #include "error.h"
+#include "lang/object_iterators.h"
 #include "lang/typecheck.h"
 #include "lang/workspace.h"
 #include "log.h"
@@ -37,11 +38,25 @@ make_complex_type(struct workspace *wk, enum complex_type t, type_tag type, type
  * ----------------------------------------------------------------------------
  */
 
+static const char *
+typechecking_type_modifier_to_str(type_tag t)
+{
+	if (t & TYPE_TAG_GLOB) {
+		return "glob";
+	} else if ((t & TYPE_TAG_LISTIFY)) {
+		return "listify";
+	}
+	return 0;
+}
+
+
 static obj
 simple_type_to_arr(struct workspace *wk, type_tag t)
 {
 	obj expected_types;
 	expected_types = make_obj(wk, obj_array);
+
+	const char *modifier = typechecking_type_modifier_to_str(t);
 
 	if (!(t & obj_typechecking_type_tag)) {
 		t = obj_type_to_tc_type(t);
@@ -72,10 +87,20 @@ simple_type_to_arr(struct workspace *wk, type_tag t)
 	obj sorted;
 	obj_array_sort(wk, NULL, expected_types, obj_array_sort_by_str, &sorted);
 
-	return sorted;
+	obj res;
+	if (modifier) {
+		obj typestr;
+		obj_array_join(wk, false, sorted, make_str(wk, "|"), &typestr);
+		res = make_obj(wk, obj_array);
+		obj_array_push(wk, res, make_strf(wk, "%s[%s]", modifier, get_str(wk, typestr)->s));
+	} else {
+		res = sorted;
+	}
+
+	return res;
 }
 
-obj
+static obj
 typechecking_type_to_arr(struct workspace *wk, type_tag t)
 {
 	if (!(t & TYPE_TAG_COMPLEX)) {
@@ -144,14 +169,8 @@ typechecking_type_to_str(struct workspace *wk, type_tag t)
 
 	t &= ~TYPE_TAG_ALLOW_NULL;
 
-	const char *modifier = 0;
-	if (t & TYPE_TAG_GLOB) {
-		t &= ~TYPE_TAG_GLOB;
-		modifier = "glob";
-	} else if ((t & TYPE_TAG_LISTIFY)) {
-		t &= ~TYPE_TAG_LISTIFY;
-		modifier = "listify";
-	}
+	const char *modifier = typechecking_type_modifier_to_str(t);
+	t &= ~(TYPE_TAG_GLOB | TYPE_TAG_LISTIFY);
 
 	obj type_arr = typechecking_type_to_arr(wk, t);
 
@@ -331,10 +350,25 @@ typecheck_complex_type(struct workspace *wk, obj got_obj, type_tag got_type, typ
 		type |= tc_disabler; // always allow disabler type
 		type &= ~(obj_typechecking_type_tag | TYPE_TAG_ALLOW_NULL);
 
+		bool listify = type & TYPE_TAG_LISTIFY;
+		type &= ~TYPE_TAG_LISTIFY;
+
 		assert(!(got_type & TYPE_TAG_MASK));
 		assert(!(type & TYPE_TAG_MASK));
 
-		return (!got_type && !type) || (got_type & type);
+		if (listify && (got_type & tc_array)) {
+			obj v;
+			obj_array_flat_for_(wk, got_obj, v, iter) {
+				if (!typecheck_complex_type(
+					    wk, v, get_obj_typechecking_type(wk, v), obj_typechecking_type_tag | type)) {
+					obj_array_flat_iter_end(wk, &iter);
+					return false;
+				}
+			}
+			return true;
+		} else {
+			return (!got_type && !type) || (got_type & type);
+		}
 	}
 
 	uint32_t idx = COMPLEX_TYPE_INDEX(type);

--- a/src/lang/vm.c
+++ b/src/lang/vm.c
@@ -3846,6 +3846,7 @@ vm_reflect_objects(struct workspace *wk)
 	vm_reflect_obj_field(obj_test, obj, depends);
 	vm_reflect_obj_field(obj_test, obj, timeout);
 	vm_reflect_obj_field(obj_test, obj, priority);
+	vm_reflect_obj_field(obj_test, obj, expected_exitcode);
 	vm_reflect_obj_field(obj_test, bool, should_fail);
 	vm_reflect_obj_field(obj_test, bool, is_parallel);
 	vm_reflect_obj_field(obj_test, bool, verbose);

--- a/src/machine_file.c
+++ b/src/machine_file.c
@@ -19,6 +19,7 @@ enum machine_file_section {
 	machine_file_section_constants,
 	machine_file_section_binaries,
 	machine_file_section_properties,
+	machine_file_section_paths,
 	machine_file_section_builtin_options,
 	machine_file_section_project_options,
 	machine_file_section_project_options_prefixed,
@@ -32,6 +33,7 @@ static const char *machine_file_section_names[machine_file_section_count] = {
 	[machine_file_section_constants] = "constants",
 	[machine_file_section_binaries] = "binaries",
 	[machine_file_section_properties] = "properties",
+	[machine_file_section_paths] = "paths",
 	[machine_file_section_builtin_options] = "built-in options",
 	[machine_file_section_project_options] = "project options",
 	[machine_file_section_build_machine] = "build_machine",
@@ -128,6 +130,7 @@ machine_file_translate_cb(void *_ctx,
 	case machine_file_section_target_machine:
 		tstr_pushf(wk, ctx->dest, "target_machine.set_properties({'%s': %s})\n", k, v);
 		break;
+	case machine_file_section_paths:
 	case machine_file_section_builtin_options:
 	case machine_file_section_project_options:
 		tstr_pushf(wk, ctx->dest, "meson.set_option('%s', %s, native: %s)\n", k, v, native);

--- a/src/machine_file.c
+++ b/src/machine_file.c
@@ -93,6 +93,12 @@ machine_file_translate_cb(void *_ctx,
 		return false;
 	}
 
+	TSTR(v_buf);
+	if (strchr(v, '#')) {
+		tstr_pushf(wk, &v_buf, "(\n\t%s\n)", v);
+		v = v_buf.buf;
+	}
+
 	switch (sect) {
 	case machine_file_section_constants: tstr_pushf(wk, ctx->dest, "%s = %s\n", k, v); break;
 	case machine_file_section_binaries: {

--- a/src/machine_file.c
+++ b/src/machine_file.c
@@ -9,6 +9,7 @@
 
 #include "error.h"
 #include "formats/ini.h"
+#include "lang/typecheck.h"
 #include "machine_file.h"
 #include "options.h"
 #include "platform/assert.h"
@@ -245,8 +246,21 @@ machine_file_eval(struct workspace *wk, const char *path, enum machine_kind mach
 
 	struct source translated_src = { .src = translated.buf, .len = translated.len, .label = translated_label.buf };
 
+	struct args_norm eval_an[] = {
+		{ .name = "~", .val = make_str(wk, fs_user_home()) },
+		ARG_TYPE_NULL,
+	};
+
 	obj res_;
-	if (!eval(wk, &translated_src, &(struct eval_opts) { build_language_meson, language_extended }, &res_)) {
+	if (!eval(wk,
+		    &translated_src,
+		    &(struct eval_opts){
+			    build_language_meson,
+			    language_extended,
+			    .compile_flags = vm_compile_mode_tilde_identifier,
+				.an = eval_an,
+		    },
+		    &res_)) {
 		goto ret;
 	}
 

--- a/src/machine_file.c
+++ b/src/machine_file.c
@@ -42,7 +42,7 @@ static const char *machine_file_section_names[machine_file_section_count] = {
 };
 
 static bool
-machine_file_section_lookup(const char *val, const char *table[], uint32_t len, uint32_t *ret)
+machine_file_section_lookup(const char *val, const char *table[], uint32_t len, uint32_t *ret, struct str *project_options_prefix)
 {
 	uint32_t i;
 	for (i = 0; i < len; ++i) {
@@ -54,6 +54,11 @@ machine_file_section_lookup(const char *val, const char *table[], uint32_t len, 
 
 	if (str_endswith(&STRL(val), &STR(":project options"))) {
 		*ret = machine_file_section_project_options_prefixed;
+		struct str_cut cut;
+		if (!str_cut(&STRL(val), &STR(":"), &cut)) {
+			UNREACHABLE;
+		}
+		*project_options_prefix = cut.before;
 		return true;
 	}
 
@@ -84,11 +89,16 @@ machine_file_translate_cb(void *_ctx,
 		return true;
 	}
 
+	struct str project_options_prefix = { 0 };
+
 	if (!sect_str) {
 		error_messagef(wk, src, location, log_error, "key not under any section");
 		return false;
-	} else if (!machine_file_section_lookup(
-			   sect_str, machine_file_section_names, machine_file_section_count, (uint32_t *)&sect)) {
+	} else if (!machine_file_section_lookup(sect_str,
+			   machine_file_section_names,
+			   machine_file_section_count,
+			   (uint32_t *)&sect,
+			   &project_options_prefix)) {
 		error_messagef(wk, src, location, log_error, "invalid section '%s'", sect_str);
 		return false;
 	}
@@ -142,7 +152,14 @@ machine_file_translate_cb(void *_ctx,
 		tstr_pushf(wk, ctx->dest, "meson.set_option('%s', %s, native: %s)\n", k, v, native);
 		break;
 	case machine_file_section_project_options_prefixed:
-		tstr_pushf(wk, ctx->dest, "# TODO: option needs prefix: meson.set_option('%s', %s)\n", k, v);
+		tstr_pushf(wk,
+			ctx->dest,
+			"meson.set_option('%.*s:%s', %s, native: %s)\n",
+			project_options_prefix.len,
+			project_options_prefix.s,
+			k,
+			v,
+			native);
 		break;
 	case machine_file_section_count: UNREACHABLE;
 	}

--- a/src/options.c
+++ b/src/options.c
@@ -27,7 +27,8 @@
 #include "platform/path.h"
 #include "wrap.h"
 
-bool initializing_builtin_options = false;
+enum initializing_builtin_options_state initializing_builtin_options_state =
+	initializing_builtin_options_state_none;
 
 const char *build_option_type_to_s[build_option_type_count] = {
 	[op_string] = "string",
@@ -594,8 +595,15 @@ create_option(struct workspace *wk, obj opts, obj opt, obj val, enum create_opti
 
 	struct obj_option *o = get_obj_option(wk, opt);
 
-	if (initializing_builtin_options) {
+	if (initializing_builtin_options_state != initializing_builtin_options_state_none) {
 		o->builtin = true;
+
+		if (initializing_builtin_options_state == initializing_builtin_options_state_project) {
+			if (!o->yield) {
+				vm_error(wk, "builtin project option %o must be set to yield", o->name);
+				return false;
+			}
+		}
 	}
 
 	obj _;
@@ -642,6 +650,7 @@ get_option_overridable(struct workspace *wk, const struct project *proj, obj ove
 	} else if (obj_dict_index_strn(wk, wk->global_opts, name->s, name->len, res)) {
 		return true;
 	} else {
+		*res = 0;
 		return false;
 	}
 }
@@ -709,7 +718,7 @@ static bool
 set_binary_from_env(struct workspace *wk, const char *envvar, const char *dest)
 {
 	obj opt;
-	if (!get_option(wk, NULL, &STRL(dest), &opt)) {
+	if (!get_option(wk, current_project(wk), &STRL(dest), &opt)) {
 		UNREACHABLE;
 	}
 
@@ -727,7 +736,7 @@ static bool
 set_compile_opt_from_env(struct workspace *wk, const char *envvar, const char *dest)
 {
 	obj opt;
-	if (!get_option(wk, NULL, &STRL(dest), &opt)) {
+	if (!get_option(wk, current_project(wk), &STRL(dest), &opt)) {
 		UNREACHABLE;
 	}
 
@@ -743,24 +752,188 @@ set_compile_opt_from_env(struct workspace *wk, const char *envvar, const char *d
 }
 
 static void
-set_str_opt_from_env(struct workspace *wk, const char *env_name, const char *opt_name, const char *split)
+make_compiler_option(struct workspace *wk, obj name)
 {
-	obj opt;
-	if (!get_option(wk, NULL, &STRL(opt_name), &opt)) {
+	obj opt = make_obj(wk, obj_option);
+	struct obj_option *o = get_obj_option(wk, opt);
+	o->name = name;
+	o->type = op_shell_array;
+	o->ip = (uint32_t)-1; // ?
+	o->builtin = true;
+	o->yield = true;
+
+	if (!create_option(wk, current_project(wk)->opts, opt, make_obj(wk, obj_array), 0)) {
 		UNREACHABLE;
 	}
+}
 
-	const char *env_val;
-	if ((env_val = os_get_env(env_name)) && *env_val) {
-		obj val;
-		if (split) {
-			val = str_split(wk, &STRL(env_val), &STRL(split));
-		} else {
-			val = make_str(wk, env_val);
-		}
+struct option_env_var_mapping {
+	const char *env_var;
+	const char *machine_suffix;
+};
 
-		set_option(wk, opt, val, option_value_source_environment, false);
+static void
+option_env_var_mapping_for_machine(const char *env_var,
+	enum machine_kind machine,
+	struct option_env_var_mapping *mapping)
+{
+	*mapping = (struct option_env_var_mapping){
+		.env_var = env_var,
+		.machine_suffix = machine == machine_kind_build ? "_FOR_BUILD" : 0,
+	};
+}
+
+static bool
+toolchain_component_option_info(struct workspace *wk, enum compiler_language l, enum toolchain_component c, enum machine_kind machine, struct option_env_var_mapping *mapping)
+{
+	const char *option_names[compiler_language_count][toolchain_component_count] = {
+		[compiler_language_c] = { "CC", "CC_LD", "AR" },
+		[compiler_language_cpp] = { "CXX", "CXX_LD", "AR" },
+		[compiler_language_objc] = { "OBJC", "OBJC_LD", "AR" },
+		[compiler_language_objcpp] = { "OBJCXX", "OBJCXX_LD", "AR" },
+		[compiler_language_nasm] = { "NASM", "NASM_LD", "AR" },
+		[compiler_language_vala] = { "VALAC", "VALAC_LD", "AR" },
+	};
+
+	const char *n = option_names[l][c];
+	if (!n) {
+		return false;
 	}
+
+	option_env_var_mapping_for_machine(n, machine, mapping);
+
+	return true;
+}
+
+static void
+toolchain_component_option_name_from_info(struct workspace *wk,
+	const struct option_env_var_mapping *mapping,
+	struct tstr *dest)
+{
+	tstr_pushf(wk, dest, "env.%s%s", mapping->env_var, mapping->machine_suffix ? mapping->machine_suffix : "");
+}
+
+bool
+toolchain_component_option_name(struct workspace *wk,
+	enum compiler_language l,
+	enum toolchain_component c,
+	enum machine_kind machine,
+	struct tstr *dest)
+{
+	struct option_env_var_mapping mapping;
+	if (!toolchain_component_option_info(wk, l, c, machine, &mapping)) {
+		return false;
+	}
+
+	toolchain_component_option_name_from_info(wk, &mapping, dest);
+	return true;
+}
+
+typedef bool (*set_env_option_with_fallback_fn)(struct workspace *wk, const char *envvar, const char *dest);
+
+void
+set_env_option_with_fallback(struct workspace *wk,
+	const char *src,
+	const char *dest,
+	enum machine_kind m,
+	set_env_option_with_fallback_fn fn)
+{
+	TSTR(env_var);
+	struct option_env_var_mapping mapping;
+	option_env_var_mapping_for_machine(src, m, &mapping);
+	tstr_pushf(wk, &env_var, "%s%s", mapping.env_var, mapping.machine_suffix ? mapping.machine_suffix : "");
+
+	if (!fn(wk, env_var.buf, dest)) {
+		if (m == machine_kind_build) {
+			// If this is a build machine opt but no _FOR_BUILD envvar was set,
+			// propogate the plain envvar's value to the _FOR_BUILD option.
+			//
+			// This lets CC=clang apply to the host machine and build machine
+			// as long as no CC_FOR_BUILD is set.
+			fn(wk, mapping.env_var, dest);
+		}
+	}
+}
+
+static void
+make_compiler_env_option(struct workspace *wk, enum compiler_language lang, enum toolchain_component comp, enum machine_kind m, bool is_first)
+{
+	struct option_env_var_mapping mapping;
+	if (!toolchain_component_option_info(wk, lang, comp, m, &mapping)) {
+		return;
+	}
+
+	TSTR(env_opt);
+	toolchain_component_option_name_from_info(wk, &mapping, &env_opt);
+	make_compiler_option(wk, tstr_into_str(wk, &env_opt));
+
+	if (is_first) {
+		set_env_option_with_fallback(wk, mapping.env_var, env_opt.buf, m, set_binary_from_env);
+	}
+}
+
+static void
+init_dynamic_compiler_options(struct workspace *wk, bool is_first)
+{
+	static struct {
+		enum compiler_language l;
+		const char *name;
+	} langs[] = {
+#define TOOLCHAIN_ENUM(lang) { compiler_language_##lang, #lang },
+		FOREACH_COMPILER_EXPOSED_LANGUAGE(TOOLCHAIN_ENUM)
+#undef TOOLCHAIN_ENUM
+	};
+
+	static const struct compile_opt_env_var {
+		const char *compile_flags;
+		const char *link_flags;
+		const char *preprocess_flags;
+	} compile_opt_env_var[compiler_language_count] = {
+		[compiler_language_c] = { "CFLAGS", "LDFLAGS", "CPPFLAGS" },
+		[compiler_language_cpp] = { "CXXFLAGS", "LDFLAGS", "CPPFLAGS" },
+		[compiler_language_objc] = { "OBJCFLAGS", "LDFLAGS", "CPPFLAGS" },
+		[compiler_language_objcpp] = { "OBJCXXFLAGS", "LDFLAGS", "CPPFLAGS" },
+	};
+
+	uint32_t i, machine;
+	for (i = 0; i < ARRAY_LEN(langs); ++i) {
+		for (machine = machine_kind_build; machine <= machine_kind_host; ++machine) {
+			const char *option_prefix = machine == machine_kind_build ? option_group_build : "";
+			const struct compile_opt_env_var *ev = &compile_opt_env_var[langs[i].l];
+
+			struct {
+				obj option;
+				const char *env_var[2];
+			} custom_env_options[] = {
+				{ make_strf(wk, "%s%s_args", option_prefix, langs[i].name), { ev->compile_flags, ev->preprocess_flags } },
+				{ make_strf(wk, "%s%s_link_args", option_prefix, langs[i].name), { ev->link_flags, ev->preprocess_flags } },
+			};
+
+			for (uint32_t o = 0; o < ARRAY_LEN(custom_env_options); ++o) {
+				make_compiler_option(wk, custom_env_options[o].option);
+				if (is_first) {
+					const char *option = get_str(wk, custom_env_options[o].option)->s;
+
+					for (uint32_t j = 0; j < ARRAY_LEN(custom_env_options[o].env_var)
+							     && custom_env_options[o].env_var[j];
+						++j) {
+						set_env_option_with_fallback(wk,
+							custom_env_options[o].env_var[j],
+							option,
+							machine,
+							set_compile_opt_from_env);
+					}
+				}
+			}
+
+			make_compiler_env_option(wk, langs[i].l, toolchain_component_compiler, machine, is_first);
+			make_compiler_env_option(wk, langs[i].l, toolchain_component_linker, machine, is_first);
+		}
+	}
+
+	// There is a single env.AR option shared by all languages
+	make_compiler_env_option(wk, compiler_language_c, toolchain_component_archiver, machine_kind_host, is_first);
+	make_compiler_env_option(wk, compiler_language_c, toolchain_component_archiver, machine_kind_build, is_first);
 }
 
 static bool
@@ -770,16 +943,21 @@ init_builtin_options(struct workspace *wk, const char *script)
 	embedded_get(wk, script, &src);
 
 	obj _;
-	initializing_builtin_options = true;
-	bool ret = eval(wk, &src, &(struct eval_opts) { build_language_meson, language_opts }, &_);
-	initializing_builtin_options = false;
-	return ret;
+	return eval(wk, &src, &(struct eval_opts){ build_language_meson, language_opts }, &_);
 }
 
 static bool
 init_per_project_options(struct workspace *wk)
 {
-	return init_builtin_options(wk, "options/per_project.meson");
+	stack_push(&wk->stack, initializing_builtin_options_state, initializing_builtin_options_state_project);
+
+	bool ok = init_builtin_options(wk, "options/per_project.meson");
+	if (ok) {
+		init_dynamic_compiler_options(wk, wk->projects.len == 1);
+	}
+
+	stack_pop(&wk->stack, initializing_builtin_options_state);
+	return ok;
 }
 
 static enum iteration_result
@@ -922,121 +1100,24 @@ setup_project_options(struct workspace *wk, const char *cwd)
 }
 
 static void
-make_compiler_option(struct workspace *wk, obj name)
+set_str_opt_from_env(struct workspace *wk, const char *env_name, const char *opt_name, const char *split)
 {
-	obj opt = make_obj(wk, obj_option);
-	struct obj_option *o = get_obj_option(wk, opt);
-	o->name = name;
-	o->type = op_shell_array;
-	o->ip = (uint32_t)-1; // ?
-	o->builtin = true;
-
-	if (!create_option(wk, wk->global_opts, opt, make_obj(wk, obj_array), 0)) {
+	obj opt;
+	if (!get_option(wk, NULL, &STRL(opt_name), &opt)) {
 		UNREACHABLE;
 	}
-}
 
-struct option_env_var_mapping {
-	const char *env_var;
-	const char *machine_suffix;
-};
-
-static void
-option_env_var_mapping_for_machine(const char *env_var,
-	enum machine_kind machine,
-	struct option_env_var_mapping *mapping)
-{
-	*mapping = (struct option_env_var_mapping){
-		.env_var = env_var,
-		.machine_suffix = machine == machine_kind_build ? "_FOR_BUILD" : 0,
-	};
-}
-
-static bool
-toolchain_component_option_info(struct workspace *wk, enum compiler_language l, enum toolchain_component c, enum machine_kind machine, struct option_env_var_mapping *mapping)
-{
-	const char *option_names[compiler_language_count][toolchain_component_count] = {
-		[compiler_language_c] = { "CC", "CC_LD", "AR" },
-		[compiler_language_cpp] = { "CXX", "CXX_LD", "AR" },
-		[compiler_language_objc] = { "OBJC", "OBJC_LD", "AR" },
-		[compiler_language_objcpp] = { "OBJCXX", "OBJCXX_LD", "AR" },
-		[compiler_language_nasm] = { "NASM", "NASM_LD", "AR" },
-		[compiler_language_vala] = { "VALAC", "VALAC_LD", "AR" },
-	};
-
-	const char *n = option_names[l][c];
-	if (!n) {
-		return false;
-	}
-
-	option_env_var_mapping_for_machine(n, machine, mapping);
-
-	return true;
-}
-
-static void
-toolchain_component_option_name_from_info(struct workspace *wk,
-	const struct option_env_var_mapping *mapping,
-	struct tstr *dest)
-{
-	tstr_pushf(wk, dest, "env.%s%s", mapping->env_var, mapping->machine_suffix ? mapping->machine_suffix : "");
-}
-
-bool
-toolchain_component_option_name(struct workspace *wk,
-	enum compiler_language l,
-	enum toolchain_component c,
-	enum machine_kind machine,
-	struct tstr *dest)
-{
-	struct option_env_var_mapping mapping;
-	if (!toolchain_component_option_info(wk, l, c, machine, &mapping)) {
-		return false;
-	}
-
-	toolchain_component_option_name_from_info(wk, &mapping, dest);
-	return true;
-}
-
-typedef bool (*set_env_option_with_fallback_fn)(struct workspace *wk, const char *envvar, const char *dest);
-
-void
-set_env_option_with_fallback(struct workspace *wk,
-	const char *src,
-	const char *dest,
-	enum machine_kind m,
-	set_env_option_with_fallback_fn fn)
-{
-	TSTR(env_var);
-	struct option_env_var_mapping mapping;
-	option_env_var_mapping_for_machine(src, m, &mapping);
-	tstr_pushf(wk, &env_var, "%s%s", mapping.env_var, mapping.machine_suffix ? mapping.machine_suffix : "");
-
-	if (!fn(wk, env_var.buf, dest)) {
-		if (m == machine_kind_build) {
-			// If this is a build machine opt but no _FOR_BUILD envvar was set,
-			// propogate the plain envvar's value to the _FOR_BUILD option.
-			//
-			// This lets CC=clang apply to the host machine and build machine
-			// as long as no CC_FOR_BUILD is set.
-			fn(wk, mapping.env_var, dest);
+	const char *env_val;
+	if ((env_val = os_get_env(env_name)) && *env_val) {
+		obj val;
+		if (split) {
+			val = str_split(wk, &STRL(env_val), &STRL(split));
+		} else {
+			val = make_str(wk, env_val);
 		}
+
+		set_option(wk, opt, val, option_value_source_environment, false);
 	}
-}
-
-static void
-make_compiler_env_option(struct workspace *wk, enum compiler_language lang, enum toolchain_component comp, enum machine_kind m)
-{
-	struct option_env_var_mapping mapping;
-	if (!toolchain_component_option_info(wk, lang, comp, m, &mapping)) {
-		return;
-	}
-
-	TSTR(env_opt);
-	toolchain_component_option_name_from_info(wk, &mapping, &env_opt);
-	make_compiler_option(wk, tstr_into_str(wk, &env_opt));
-
-	set_env_option_with_fallback(wk, mapping.env_var, env_opt.buf, m, set_binary_from_env);
 }
 
 bool
@@ -1047,70 +1128,18 @@ init_global_options(struct workspace *wk)
 	}
 	wk->init_flags |= workspace_init_flag_global_options;
 
-	if (!init_builtin_options(wk, "options/global.meson")) {
-		return false;
-	}
+	stack_push(&wk->stack, initializing_builtin_options_state, initializing_builtin_options_state_global);
 
-	static struct {
-		enum compiler_language l;
-		const char *name;
-	} langs[] = {
-#define TOOLCHAIN_ENUM(lang) { compiler_language_##lang, #lang },
-		FOREACH_COMPILER_EXPOSED_LANGUAGE(TOOLCHAIN_ENUM)
-#undef TOOLCHAIN_ENUM
-	};
-
-	static const struct compile_opt_env_var {
-		const char *compile_flags;
-		const char *link_flags;
-		const char *preprocess_flags;
-	} compile_opt_env_var[compiler_language_count] = {
-		[compiler_language_c] = { "CFLAGS", "LDFLAGS", "CPPFLAGS" },
-		[compiler_language_cpp] = { "CXXFLAGS", "LDFLAGS", "CPPFLAGS" },
-		[compiler_language_objc] = { "OBJCFLAGS", "LDFLAGS", "CPPFLAGS" },
-		[compiler_language_objcpp] = { "OBJCXXFLAGS", "LDFLAGS", "CPPFLAGS" },
-	};
-
-	uint32_t i, machine;
-	for (i = 0; i < ARRAY_LEN(langs); ++i) {
-		for (machine = machine_kind_build; machine <= machine_kind_host; ++machine) {
-			const char *option_prefix = machine == machine_kind_build ? option_group_build : "";
-			const struct compile_opt_env_var *ev = &compile_opt_env_var[langs[i].l];
-
-			struct {
-				obj option;
-				const char *env_var[2];
-			} custom_env_options[] = {
-				{ make_strf(wk, "%s%s_args", option_prefix, langs[i].name), { ev->compile_flags, ev->preprocess_flags } },
-				{ make_strf(wk, "%s%s_link_args", option_prefix, langs[i].name), { ev->link_flags, ev->preprocess_flags } },
-			};
-
-			for (uint32_t o = 0; o < ARRAY_LEN(custom_env_options); ++o) {
-				make_compiler_option(wk, custom_env_options[o].option);
-				const char *option = get_str(wk, custom_env_options[o].option)->s;
-
-				for (uint32_t j = 0;
-					j < ARRAY_LEN(custom_env_options[o].env_var) && custom_env_options[o].env_var[j];
-					++j) {
-					set_env_option_with_fallback(
-						wk, custom_env_options[o].env_var[j], option, machine, set_compile_opt_from_env);
-				}
-			}
-
-			make_compiler_env_option(wk, langs[i].l, toolchain_component_compiler, machine);
-			make_compiler_env_option(wk, langs[i].l, toolchain_component_linker, machine);
-		}
-	}
-	// There is a single env.AR option shared by all languages
-	make_compiler_env_option(wk, compiler_language_c, toolchain_component_archiver, machine_kind_host);
-	make_compiler_env_option(wk, compiler_language_c, toolchain_component_archiver, machine_kind_build);
+	bool ok = init_builtin_options(wk, "options/global.meson");
 
 	set_str_opt_from_env(wk, "PKG_CONFIG_PATH", "pkg_config_path", ENV_PATH_SEP_STR);
 
 	set_binary_from_env(wk, "NINJA", "env.NINJA");
 	set_binary_from_env(wk, "PKG_CONFIG", "env.PKG_CONFIG");
 
-	return true;
+	stack_pop(&wk->stack, initializing_builtin_options_state);
+
+	return ok;
 }
 
 bool

--- a/src/options.c
+++ b/src/options.c
@@ -540,7 +540,7 @@ set_option(struct workspace *wk, obj opt, obj new_val, enum option_value_source 
 	switch (o->type) {
 	case op_combo: {
 		if (!obj_array_in(wk, o->choices, new_val)) {
-			vm_error_at(wk, o->ip, "'%o' is not one of %o", new_val, o->choices);
+			vm_error_at(wk, o->ip, "%o is not one of %o", new_val, o->choices);
 			return false;
 		}
 

--- a/src/options.c
+++ b/src/options.c
@@ -1394,6 +1394,21 @@ get_option_backend(struct workspace *wk)
 	}
 }
 
+enum opt_namingscheme
+get_option_namingscheme(struct workspace *wk, const struct project *proj, obj overrides)
+{
+	obj opt;
+	get_option_value_overridable(wk, proj, overrides, "namingscheme", &opt);
+	const struct str *str = get_str(wk, opt);
+	if (str_eql(str, &STR("classic"))) {
+		return opt_namingscheme_classic;
+	} else if (str_eql(str, &STR("platform"))) {
+		return opt_namingscheme_platform;
+	} else {
+		UNREACHABLE_RETURN;
+	}
+}
+
 /* options loading */
 
 bool

--- a/src/options.c
+++ b/src/options.c
@@ -90,11 +90,6 @@ parse_config_string(struct workspace *wk, const struct str *ss, struct option_ov
 		key = cur;
 	}
 
-	if (have_subproject && !subproject.len) {
-		LOG_E("missing subproject in option '%s'", ss->s);
-		return false;
-	}
-
 	if (!key.len) {
 		LOG_E("missing key in option '%s'", ss->s);
 		return false;
@@ -108,7 +103,11 @@ parse_config_string(struct workspace *wk, const struct str *ss, struct option_ov
 		oo->val = make_strn(wk, val.s, val.len);
 	}
 	if (have_subproject) {
-		oo->proj = make_strn(wk, subproject.s, subproject.len);
+		if (subproject.len) {
+			oo->proj = make_strn(wk, subproject.s, subproject.len);
+		} else {
+			oo->master_project_only = true;
+		}
 	}
 
 	return true;

--- a/src/platform/windows/run_cmd.c
+++ b/src/platform/windows/run_cmd.c
@@ -155,9 +155,9 @@ copy_pipes(struct workspace *wk, struct run_cmd_ctx *ctx, bool all)
 		struct tstr *tstr = pipe == &ctx->pipe_out ? &ctx->out : &ctx->err;
 		FILE* tee_out = 0;
 		if (ctx->flags & run_cmd_ctx_flag_tee) {
-			tee_out = pipe == &ctx->pipe_out : stdout : stderr;
+			tee_out = pipe == &ctx->pipe_out ? stdout : stderr;
 		}
-		if (!copy_pipe(wk, ctx, pipe, tstr, &count_read)) {
+		if (!copy_pipe(wk, ctx, pipe, tstr, tee_out, &count_read)) {
 			return false;
 		}
 

--- a/src/platform/windows/run_cmd.c
+++ b/src/platform/windows/run_cmd.c
@@ -72,6 +72,7 @@ copy_pipe(struct workspace *wk,
 	struct run_cmd_ctx *ctx,
 	struct win_pipe_inst *pipe,
 	struct tstr *tstr,
+	FILE *tee_out,
 	uint32_t *count_read)
 {
 	if (pipe->is_eof) {
@@ -96,6 +97,9 @@ copy_pipe(struct workspace *wk,
 		TracyCPlot("Pipe read bytes", bytes_read);
 		*count_read += bytes_read;
 		tstr_pushn(wk, tstr, pipe->overlapped_buf, bytes_read);
+		if (tee_out) {
+			fwrite(pipe->overlapped_buf, bytes_read, 1, tee_out);
+		}
 	}
 	memset(&pipe->overlapped, 0, sizeof(pipe->overlapped));
 	pipe->is_reading = true;
@@ -149,6 +153,10 @@ copy_pipes(struct workspace *wk, struct run_cmd_ctx *ctx, bool all)
 		pipe = (struct win_pipe_inst *)pipe_ptr;
 
 		struct tstr *tstr = pipe == &ctx->pipe_out ? &ctx->out : &ctx->err;
+		FILE* tee_out = 0;
+		if (ctx->flags & run_cmd_ctx_flag_tee) {
+			tee_out = pipe == &ctx->pipe_out : stdout : stderr;
+		}
 		if (!copy_pipe(wk, ctx, pipe, tstr, &count_read)) {
 			return false;
 		}

--- a/src/script/meson.build
+++ b/src/script/meson.build
@@ -20,6 +20,7 @@ foreach s : [
     'lib/cmake_prelude.meson',
     'modules/gnome.meson',
     'modules/i18n.meson',
+    'modules/snippets.meson',
     'modules/wayland.meson',
     'modules/windows.meson',
     'options/global.meson',

--- a/src/script/modules/gnome.meson
+++ b/src/script/modules/gnome.meson
@@ -436,6 +436,8 @@ func gdbus_codegen(
     object_manager bool: false,
     annotations list[list[str]]: [],
     docbook str:,
+    markdown str:,
+    rst str:,
     build_by_default bool: true,
     install_dir str: get_option('includedir'),
     install_header bool: false,
@@ -491,29 +493,40 @@ func gdbus_codegen(
     )
     targets = [body, header]
 
-    if not is_null(docbook)
+    doc_formats = [
+        {'name': 'docbook', 'val': docbook},
+        {'name': 'rst', 'val': rst},
+        {'name': 'md', 'val': markdown},
+    ]
+
+    foreach fmt : doc_formats
+        if is_null(fmt.val)
+            continue
+        endif
+
         outputs = []
 
         foreach xml : xml_files
-            outputs += '@0@.@1@'.format(docbook, fs.name(xml))
+            outputs += '@0@.@1@'.format(fmt.val, fs.name(xml))
         endforeach
 
         doc = custom_target(
-            name + '-docbook',
+            name + '-' + fmt.name,
             depends: body,
             build_by_default: build_by_default,
             input: xml_files,
             output: outputs,
+            # build_subdir: 'generated-gdbus-docs-' + fmt.name,
             command: [
                 cmd,
                 '--output-directory', '@OUTDIR@',
-                '--generate-docbook', docbook,
+                '--generate-' + fmt.name, fmt.val,
                 '@INPUT@',
             ],
         )
 
         targets += doc
-    endif
+    endforeach
 
     return targets
 endfunc

--- a/src/script/modules/i18n.meson
+++ b/src/script/modules/i18n.meson
@@ -425,4 +425,29 @@ M.itstool_join = func(
 
 endfunc
 
+## Invokes the xgettext program on given sources, to generate a .pot file. This
+## function is to be used when the gettext function workflow is not suitable
+## for your project. For example, it can be used to produce separate .pot
+## files for each executable.
+M.xgettext = func(
+    ## The name of the resulting pot file.
+    name str,
+    ## Source files or targets. May be a list of string, File, build_tgt, or
+    ## custom_tgt returned from other calls to this function.
+    sources glob[str|file|build_tgt|custom_tgt],
+    ## if true, will merge the resulting pot file with extracted pot files
+    ## related to dependencies of the given source targets. For instance, if you
+    ## build an executable, then you may want to merge the executable
+    ## translations with the translations from the dependent libraries.
+    recursive bool: false,
+    ## if true, will add the resulting pot file to install targets.
+    install bool: false,
+    ## install tag to use for the install target.
+    install_tag str:,
+    ## directory where to install the resulting pot file.
+    install_dir str:,
+) -> custom_tgt
+    error('unimplemented')
+endfunc
+
 return M

--- a/src/script/modules/i18n.meson
+++ b/src/script/modules/i18n.meson
@@ -434,7 +434,7 @@ M.xgettext = func(
     name str,
     ## Source files or targets. May be a list of string, File, build_tgt, or
     ## custom_tgt returned from other calls to this function.
-    sources glob[str|file|build_tgt|custom_tgt],
+    sources glob[build_tgt|custom_tgt|file|str],
     ## if true, will merge the resulting pot file with extracted pot files
     ## related to dependencies of the given source targets. For instance, if you
     ## build an executable, then you may want to merge the executable
@@ -447,6 +447,7 @@ M.xgettext = func(
     ## directory where to install the resulting pot file.
     install_dir str:,
 ) -> custom_tgt
+    _ = [name, sources, recursive, install, install_tag, install_dir]
     error('unimplemented')
 endfunc
 

--- a/src/script/modules/snippets.meson
+++ b/src/script/modules/snippets.meson
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Stone Tickle <lattis@mochiro.moe>
+# SPDX-License-Identifier: GPL-3.0-only
+
+fs = import('fs')
+
+M = {}
+
+## Generate a header file that defines macros to be used to mark all public
+## APIs of a library. Depending on the platform, this will typically use
+## __declspec(dllexport), __declspec(dllimport) or
+## __attribute__((visibility("default"))). It is compatible with C, C++, ObjC and
+## ObjC++ languages. The content of the header is static regardless of the
+## compiler used.
+M.symbol_visibility_header = func(
+    header_name str,
+    ## Prefix for generated macros, defaults to the current project name. It
+    ## will be converted to upper case with all non-alphanumeric characters
+    ## replaced by an underscore _. It is only used for api, compilation and
+    ## static_compilation default values.
+    namespace str:,
+    ## Name of the macro used to mark public APIs. Defaults to <NAMESPACE>_API.
+    api str:,
+    ## Name of a macro defined only when compiling the library. Defaults to
+    ## <NAMESPACE>_COMPILATION.
+    compilation str:,
+    ## Name of a macro defined only when compiling or using static library.
+    ## Defaults to <NAMESPACE>_STATIC_COMPILATION.
+    static_compilation str:,
+    ## If set to true, <NAMESPACE>_STATIC_COMPILATION is defined inside the
+    ## generated header. In that case the header can only be used for building a
+    ## static library. By default it is true when default_library=static, and
+    ## false otherwise.
+    static_only bool:,
+) -> file
+    if is_null(namespace)
+        namespace = meson.project_name()
+    endif
+    namespace = namespace.underscorify()
+    if namespace[0] in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+        namespace = f'_@namespace@'
+    endif
+
+    if is_null(api)
+        api = f'@namespace@_API'
+    endif
+
+    if is_null(compilation)
+        compilation = f'@namespace@_COMPILATION'
+    endif
+
+    if is_null(static_compilation)
+        static_compilation = f'@namespace@_STATIC_COMPILATION'
+    endif
+
+    if is_null(static_only)
+        default_library = get_option('default_library')
+        static_only = default_library == 'static'
+    endif
+
+    content = [
+        '// SPDX-license-identifier: 0BSD OR CC0-1.0 OR WTFPL OR Apache-2.0 OR LGPL-2.0-or-later',
+        '#pragma once',
+    ]
+    if static_only
+        content += [
+            f'#ifndef @static_compilation@',
+            f'#  define @static_compilation@',
+            f'#endif /* @static_compilation@ */',
+        ]
+    endif
+    content += [
+        f'#if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(@static_compilation@)',
+        f'#  define @api@_EXPORT __declspec(dllexport)',
+        f'#  define @api@_IMPORT __declspec(dllimport)',
+        f'#elif defined(__OS2__) && !defined(@static_compilation@)',
+        f'#  define @api@_EXPORT __declspec(dllexport)',
+        f'#  define @api@_IMPORT',
+        f'#elif __GNUC__ >= 4',
+        f'#  define @api@_EXPORT __attribute__((visibility("default")))',
+        f'#  define @api@_IMPORT',
+        f'#else',
+        f'#  define @api@_EXPORT',
+        f'#  define @api@_IMPORT',
+        f'#endif',
+        f'',
+        f'#ifdef @compilation@',
+        f'#  define @api@ @api@_EXPORT extern',
+        f'#else',
+        f'#  define @api@ @api@_IMPORT extern',
+        f'#endif',
+        f'',
+    ]
+    p(content)
+
+    header_path = files(meson.current_build_dir() / header_name)[0]
+
+    fs.write(header_path, '\n'.join(content))
+    return header_path
+endfunc
+
+return M

--- a/src/script/modules/snippets.meson
+++ b/src/script/modules/snippets.meson
@@ -90,7 +90,6 @@ M.symbol_visibility_header = func(
         f'#endif',
         f'',
     ]
-    p(content)
 
     header_path = files(meson.current_build_dir() / header_name)[0]
 

--- a/src/script/modules/windows.meson
+++ b/src/script/modules/windows.meson
@@ -15,7 +15,14 @@ comp_types = {
     },
     'windres': {
         'suffix': 'o',
-        'args': ['@INPUT@', '@OUTPUT@'],
+        'args': [
+            '@INPUT@',
+            '@OUTPUT@',
+            '--preprocessor-arg=-MD',
+            '--preprocessor-arg=-MQ@OUTPUT@',
+            '--preprocessor-arg=-MF@DEPFILE@',
+        ],
+        'depfile': '@OUTPUT@.d',
         'inc': func(path str) -> str
             return f'-I@path@'
         endfunc,
@@ -49,6 +56,9 @@ M.compile_resources = func(
     ## referenced resource files, and added to the preprocessor include search
     ## path
     include_directories list[inc|str]: [],
+    ## automatically add current build and source directories to
+    ## include_directories
+    implicit_include_directories bool: false,
 ) -> list[custom_tgt]
     comp = find_compiler()
 
@@ -56,7 +66,12 @@ M.compile_resources = func(
         include_directories += '@BUILD_ROOT@' / fs.parent(d.full_path())
     endforeach
 
-    foreach inc : include_directories
+    includes = include_directories
+    if implicit_include_directories
+        includes += [meson.current_source_dir(), meson.current_build_dir()]
+    endif
+
+    foreach inc : includes
         args += comp.inc(inc.full_path())
     endforeach
 
@@ -71,6 +86,12 @@ M.compile_resources = func(
         endif
     endforeach
 
+    kwargs = {}
+
+    if 'depfile' in comp
+        kwargs.depfile = comp.depfile
+    endif
+
     res = []
     foreach rc : rcs_flat.flatten()
         name = rc.full_path().underscorify()
@@ -80,6 +101,7 @@ M.compile_resources = func(
             command: [comp.prog, args],
             depend_files: depend_files,
             depends: depends,
+            kwargs: kwargs,
         )
     endforeach
 

--- a/src/script/options/global.meson
+++ b/src/script/options/global.meson
@@ -186,6 +186,12 @@ option(
     value: false,
     description: 'Activate Visual Studio environment',
 )
+option(
+    'os2_emxomf',
+    type: 'boolean',
+    value: false,
+    description: 'Use OMF format on OS/2',
+) # TODO
 
 # Base options
 option(

--- a/src/script/options/global.meson
+++ b/src/script/options/global.meson
@@ -121,32 +121,12 @@ option(
     description: 'Maximum number of linker processes to run or 0 for no limit',
 )
 option(
-    'buildtype',
-    type: 'combo',
-    value: 'debug',
-    choices: [
-        'plain',
-        'debug',
-        'debugoptimized',
-        'release',
-        'minsize',
-        'custom',
-    ],
-    description: 'Build type to use',
-)
-option(
     'cmake_prefix_path',
     type: 'array',
     value: [],
     description: 'List of additional prefixes for cmake to search',
     per_machine: true,
 ) # TODO
-option(
-    'debug',
-    type: 'boolean',
-    value: true,
-    description: 'Enable debug symbols and other information',
-)
 option(
     'errorlogs',
     type: 'boolean',
@@ -169,13 +149,6 @@ option(
     description: 'Build directory layout',
 )
 option(
-    'optimization',
-    type: 'combo',
-    value: '0',
-    choices: ['plain', '0', 'g', '1', '2', '3', 's'],
-    description: 'Optimization level',
-)
-option(
     'pkg_config_path',
     type: 'array',
     value: [],
@@ -187,26 +160,6 @@ option(
     type: 'boolean',
     value: true,
     description: 'Split stdout and stderr in test logs',
-) # TODO
-option(
-    'strip',
-    type: 'boolean',
-    value: false,
-    description: 'Strip targets on install',
-) # TODO
-option(
-    'unity',
-    type: 'combo',
-    value: 'off',
-    choices: ['off'],
-    description: 'Unity build',
-)
-option(
-    'unity_size',
-    type: 'integer',
-    value: 4,
-    min: 2,
-    description: 'Unity block size',
 ) # TODO
 option(
     'wrap_mode',
@@ -222,11 +175,16 @@ option(
     description: 'Force fallback for those subprojects',
 )
 option(
-    'default_both_libraries',
-    type: 'combo',
-    choices: ['auto', 'static', 'shared'],
-    value: 'auto',
-    description: 'Default library type for both_libraries',
+    'prefer_static',
+    type: 'boolean',
+    value: false,
+    description: 'Whether to try static linking before shared linking',
+)
+option(
+    'vsenv',
+    type: 'boolean',
+    value: false,
+    description: 'Activate Visual Studio environment',
 )
 
 # Base options
@@ -395,66 +353,6 @@ option(
     type: 'array',
     value: [],
     description: 'Specify an exe wrapper to run executables compiled for the host machine',
-)
-
-# Compiler options
-
-option(
-    'c_winlibs',
-    type: 'array',
-    value: [],
-    per_machine: true,
-)
-option(
-    'c_thread_count',
-    type: 'integer',
-    value: 4,
-    min: 0,
-    per_machine: true,
-) # TODO
-option(
-    'cpp_debugstl',
-    type: 'boolean',
-    value: false,
-    per_machine: true,
-) # TODO
-option(
-    'cpp_eh',
-    type: 'combo',
-    value: 'default',
-    choices: ['none', 'default', 'a', 's', 'sc'],
-    per_machine: true,
-) # TODO
-option(
-    'cpp_rtti',
-    type: 'boolean',
-    value: true,
-    per_machine: true,
-) # TODO
-option(
-    'cpp_thread_count',
-    type: 'integer',
-    value: 4,
-    min: 0,
-    per_machine: true,
-) # TODO
-option(
-    'cpp_winlibs',
-    type: 'array',
-    value: [],
-    per_machine: true,
-) # TODO
-option(
-    'prefer_static',
-    type: 'boolean',
-    value: false,
-    description: 'Whether to try static linking before shared linking',
-)
-option(
-    'vsenv',
-    type: 'boolean',
-    value: false,
-    description: 'Activate Visual Studio environment',
 )
 
 # Python specific options

--- a/src/script/options/global.meson
+++ b/src/script/options/global.meson
@@ -273,17 +273,8 @@ option(
 )
 option(
     'b_sanitize',
-    type: 'combo',
-    choices: [
-        'none',
-        'address',
-        'thread',
-        'undefined',
-        'memory',
-        'leak',
-        'address,undefined',
-    ],
-    value: 'none',
+    type: 'array',
+    value: [],
     description: 'Code sanitizer to use',
 )
 option(

--- a/src/script/options/per_project.meson
+++ b/src/script/options/per_project.meson
@@ -40,3 +40,126 @@ option(
     value: 'none',
     per_machine: true,
 )
+
+option(
+    'buildtype',
+    yield: true,
+    type: 'combo',
+    value: 'debug',
+    choices: [
+        'plain',
+        'debug',
+        'debugoptimized',
+        'release',
+        'minsize',
+        'custom',
+    ],
+    description: 'Build type to use',
+)
+option(
+    'optimization',
+    yield: true,
+    type: 'combo',
+    value: '0',
+    choices: ['plain', '0', 'g', '1', '2', '3', 's'],
+    description: 'Optimization level',
+)
+option(
+    'debug',
+    yield: true,
+    type: 'boolean',
+    value: true,
+    description: 'Enable debug symbols and other information',
+)
+option(
+    'default_both_libraries',
+    yield: true,
+    type: 'combo',
+    choices: ['auto', 'static', 'shared'],
+    value: 'auto',
+    description: 'Default library type for both_libraries',
+)
+option(
+    'namingscheme',
+    yield: true,
+    type: 'combo',
+    choices: ['platform', 'classic'],
+    value: 'classic',
+    description: 'Library naming scheme to use',
+) # TODO
+option(
+    'strip',
+    yield: true,
+    type: 'boolean',
+    value: false,
+    description: 'Strip targets on install',
+) # TODO
+option(
+    'unity',
+    yield: true,
+    type: 'combo',
+    value: 'off',
+    choices: ['off'],
+    description: 'Unity build',
+)
+option(
+    'unity_size',
+    yield: true,
+    type: 'integer',
+    value: 4,
+    min: 2,
+    description: 'Unity block size',
+) # TODO
+
+option(
+    'c_winlibs',
+    yield: true,
+    type: 'array',
+    value: [],
+    per_machine: true,
+)
+option(
+    'c_thread_count',
+    yield: true,
+    type: 'integer',
+    value: 4,
+    min: 0,
+    per_machine: true,
+) # TODO
+option(
+    'cpp_debugstl',
+    yield: true,
+    type: 'boolean',
+    value: false,
+    per_machine: true,
+) # TODO
+option(
+    'cpp_eh',
+    yield: true,
+    type: 'combo',
+    value: 'default',
+    choices: ['none', 'default', 'a', 's', 'sc'],
+    per_machine: true,
+) # TODO
+option(
+    'cpp_rtti',
+    yield: true,
+    type: 'boolean',
+    value: true,
+    per_machine: true,
+) # TODO
+option(
+    'cpp_thread_count',
+    yield: true,
+    type: 'integer',
+    value: 4,
+    min: 0,
+    per_machine: true,
+) # TODO
+option(
+    'cpp_winlibs',
+    yield: true,
+    type: 'array',
+    value: [],
+    per_machine: true,
+) # TODO

--- a/src/script/runtime/toolchains.meson
+++ b/src/script/runtime/toolchains.meson
@@ -148,8 +148,12 @@ toolchain.register_linker(
                 return ['-rpath,' + s1]
             endif
         endfunc,
-        'sanitize': func(_c compiler, s1 str) -> list[str]
-            return ['-fsanitize=' + s1]
+        'sanitize': func(_c compiler, sanitizers list[str]) -> list[str]
+            res = []
+            foreach sanitizer : sanitizers
+                res += [f'-fsanitize=@sanitizer@']
+            endforeach
+            return res
         endfunc,
         'shared_module': ['-shared'],
         'soname': func(_c compiler, s1 str) -> list[str]
@@ -203,9 +207,7 @@ toolchain.register_linker(
         'rpath': func(_c compiler, s1 str) -> list[str]
             return ['-rpath,' + s1]
         endfunc,
-        'sanitize': func(_c compiler, s1 str) -> list[str]
-            return ['-fsanitize=' + s1]
-        endfunc,
+        'sanitize': toolchain.handler('linker', 'ld', 'sanitize'),
         'shared_module': ['-bundle'],
         'version': ['-v'],
         'whole_archive': func(_c compiler, s1 str) -> list[str]
@@ -596,9 +598,7 @@ toolchain.register_compiler(
         endfunc,
         'pie': ['-fPIE'],
         'preprocess_only': ['-E', '-P'],
-        'sanitize': func(_c compiler, s1 str) -> list[str]
-            return ['-fsanitize=' + s1]
-        endfunc,
+        'sanitize': toolchain.handler('linker', 'ld', 'sanitize'),
         'set_std': func(_c compiler, s1 str) -> list[str]
             return ['-std=' + s1]
         endfunc,
@@ -905,8 +905,12 @@ toolchain.register_compiler(
             endif
         endfunc,
         'preprocess_only': ['/EP'],
-        'sanitize': func(_c compiler, s1 str) -> list[str]
-            return ['/fsanitize=' + s1]
+        'sanitize': func(_c compiler, sanitizers list[str]) -> list[str]
+            res = []
+            foreach sanitizer : sanitizers
+                res += [f'/fsanitize=@sanitizer@']
+            endforeach
+            return res
         endfunc,
         'set_std': func(_c compiler, s1 str) -> list[str]
             return [f'/std:@s1@']

--- a/src/script/runtime/toolchains.meson
+++ b/src/script/runtime/toolchains.meson
@@ -783,6 +783,26 @@ toolchain.register_compiler(
     },
 )
 
+func crt_opt_normalize(s str, debug bool) -> str
+    if s == 'from_buildtype'
+        return debug ? 'dll_dbg' : 'dll'
+    elif s == 'static_from_buildtype'
+        return debug ? 'static_dbg' : 'static'
+    elif s == 'none'
+        return 'none'
+    elif s == 'md'
+        return 'dll'
+    elif s == 'mdd'
+        return 'dll_dbg'
+    elif s == 'mt'
+        return 'static'
+    elif s == 'mtd'
+        return 'static_dbg'
+    endif
+
+    error(f'invalid crt opt: @s@')
+endfunc
+
 toolchain.register_compiler(
     'clang',
     inherit: 'gcc',
@@ -814,6 +834,19 @@ toolchain.register_compiler(
         'can_compile_llvm_ir': true,
         'color_output': func(_c compiler, s str) -> list[str]
             return ['-fdiagnostics-color=' + s]
+        endfunc,
+        'crt': func(c compiler, s str, debug bool) -> list[str]
+            if c.get_internal_linker_id() not in ['link', 'lld-link']
+                return []
+            endif
+
+            s = crt_opt_normalize(s, debug)
+
+            if s == 'none'
+                error('"none" not currently handled')
+            endif
+
+            return ['-fms-runtime-lib=@s@']
         endfunc,
         'emit_pch': ['-Xclang', '-emit-pch'],
         'include_pch': func(_c compiler, s1 str) -> list[str]
@@ -857,14 +890,20 @@ toolchain.register_compiler(
         endfunc,
         'compile_only': ['/c'],
         'crt': func(_c compiler, s str, debug bool) -> list[str]
-            if s == 'from_buildtype'
-                return debug ? ['/MDd'] : ['/MD']
-            elif s == 'static_from_buildtype'
-                return debug ? ['/MTd'] : ['/MT']
-            else
-                return [s]
+            s = crt_opt_normalize(s, debug)
+            if s == 'none'
+                return []
             endif
+            return [
+                {
+                    'static': '/MT',
+                    'static_dbg': '/MTd',
+                    'dll': '/MD',
+                    'dll_dbg': '/MDd',
+                }[s],
+            ]
         endfunc,
+
         'debug': ['/Zi'],
         'debugfile': func(_c compiler, s str) -> list[str]
             return [f'/Fd@s@.pdb']

--- a/src/toolchains.c
+++ b/src/toolchains.c
@@ -497,12 +497,12 @@ toolchain_component_detect(struct workspace *wk,
 		TSTR(opt_name);
 		if (toolchain_component_option_name(wk, compiler->lang, component, compiler->machine, &opt_name)) {
 			obj cmd_arr_opt = 0;
-			if (!get_option(wk, NULL, &TSTR_STR(&opt_name), &cmd_arr_opt)) {
+			if (!get_option(wk, current_project(wk), &TSTR_STR(&opt_name), &cmd_arr_opt)) {
 				UNREACHABLE;
 			}
 			struct obj_option *cmd_arr = get_obj_option(wk, cmd_arr_opt);
 
-			if (cmd_arr->source > option_value_source_default) {
+			if (cmd_arr->source > option_value_source_default && get_obj_array(wk, cmd_arr->val)->len) {
 				candidates = ar_maken(wk->a_scratch, obj, 1);
 				candidates_len = 1;
 				candidates[0] = cmd_arr->val;

--- a/src/toolchains.c
+++ b/src/toolchains.c
@@ -17,6 +17,7 @@
 #include "buf_size.h"
 #include "error.h"
 #include "formats/ansi.h"
+#include "functions/external_program.h"
 #include "functions/kernel.h"
 #include "functions/string.h"
 #include "guess.h"
@@ -661,7 +662,7 @@ toolchain_component_detect(struct workspace *wk,
 
 		// normalize the candidate into a command array with a full path to
 		// argv0, or skip if not found
-		obj cmd_arr;
+		obj cmd_arr = 0;
 		if (do_linker_passthrough) {
 			// This cmd_arr was already resolved since it is the compiler
 			// cmd_arr
@@ -682,7 +683,8 @@ toolchain_component_detect(struct workspace *wk,
 			}
 
 			struct obj_external_program *ep = get_obj_external_program(wk, found_prog);
-			obj_array_dup(wk, ep->cmd_array, &cmd_arr);
+			obj ep_cmd_arr = obj_external_program_cmd_array(wk, ep, 0);
+			obj_array_dup(wk, ep_cmd_arr, &cmd_arr);
 			obj_array_extend(wk, cmd_arr, obj_array_slice(wk, c, 1, get_obj_array(wk, c)->len));
 		}
 
@@ -901,7 +903,7 @@ toolchain_component_compiler_apply_wrapper(struct workspace *wk, struct obj_comp
 			obj cmd_arr = compiler->cmd_arr[toolchain_component_compiler];
 			obj new_cmd_arr = make_obj(wk, obj_array);
 
-			obj_array_extend(wk, new_cmd_arr, wrap_ep->cmd_array);
+			obj_array_extend(wk, new_cmd_arr, obj_external_program_cmd_array(wk, wrap_ep, 0));
 			obj_array_extend(wk, new_cmd_arr, cmd_arr);
 			compiler->cmd_arr[toolchain_component_compiler] = new_cmd_arr;
 			found = true;

--- a/subprojects/meson-docs.wrap
+++ b/subprojects/meson-docs.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-docs
-revision = 24316bafa671bed5727b05fbf3214cdad953938f
+revision = 589bc119dfc06bb678fb1688488e508ec51a87b8
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = 30b81b3b7c1755cebd23f9eff9530d0bc8f18748
+revision = 6a2a5f3004a5f2778868f8a8d8e5438cbe2ef85b
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = 6b25561d086a50b01b31088b47c46b484ea6e73b
+revision = 7d90d0c5186926291f989f0cd4e98a7027996354
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = de07a95754f4adf61e1158017cbc8e79d08606a9
+revision = bfe6bb398d150f9e7f8510b07a024a3f59be4dba
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = cc8e73a21e0db5bedf8c981b904e579f2788dde6
+revision = de07a95754f4adf61e1158017cbc8e79d08606a9
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = bfe6bb398d150f9e7f8510b07a024a3f59be4dba
+revision = 55db9b67130afaf5291306f1381c3eef5315cc35
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = 14a47fe1512deb9e69a176ac7ee2db35cbbc9885
+revision = cc8e73a21e0db5bedf8c981b904e579f2788dde6
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = 7d90d0c5186926291f989f0cd4e98a7027996354
+revision = c77beff10e7cd88f1c9f0894f4fb38b5ed77a56a
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = 55db9b67130afaf5291306f1381c3eef5315cc35
+revision = 6b25561d086a50b01b31088b47c46b484ea6e73b
 depth = 1

--- a/subprojects/meson-tests.wrap
+++ b/subprojects/meson-tests.wrap
@@ -3,5 +3,5 @@
 
 [wrap-git]
 url = https://github.com/muon-build/meson-tests
-revision = c77beff10e7cd88f1c9f0894f4fb38b5ed77a56a
+revision = 30b81b3b7c1755cebd23f9eff9530d0bc8f18748
 depth = 1

--- a/tests/project/meson.build
+++ b/tests/project/meson.build
@@ -117,6 +117,8 @@ foreach t : tests
         endforeach
 
         setup_options = result
+    elif 'options' in props
+        setup_options = [props['options']]
     endif
 
     foreach opts : setup_options

--- a/tests/project/runner.meson
+++ b/tests/project/runner.meson
@@ -62,6 +62,14 @@ steps.analyze = func()
 endfunc
 
 steps.setup = func()
+    preload_opts = []
+    foreach type : ['cross', 'native']
+        path = source / f'@type@file.ini'
+        if fs.exists(path)
+            preload_opts += f'-p@type@:@path@'
+        endif
+    endforeach
+
     setup_result = run_command(
         muon,
         '-vC', source,
@@ -69,6 +77,7 @@ steps.setup = func()
         '-Dprefix=/usr',
         '-Denv.NINJA=' + util.repr(ninja),
         extra_setup_opts,
+        preload_opts,
         build,
     )
 


### PR DESCRIPTION
# 1.8.0
[source](https://mesonbuild.com/Release-notes-for-1-8-0.html)
- [x] New argument android_exe_type for executables *stub*
- [x] Changes to the b_sanitize option
- [x] i18n module xgettext *stub*
- [x] version_compare now accept multiple compare strings
- [ ] ~Improvements to Objective-C and Objective-C++~
- [x] Per project subproject options rewrite*
  - Note: internals are done, but some questionable edge cases such as supporting -U and -A, or setting project options without yielding them using -D:foo=bar syntax are not done yet.
# 1.9.0
[source](https://mesonbuild.com/Release-notes-for-1-9-0.html)
- [x] Array .flatten() method
- [ ] ~Support response files for custom targets~ (postponing for now, also unclear why this would be needed since custom_targets already have rsp-like behavior using `muon internal exe -a`)
- [x] Added license keyword to pkgconfig.generate
- [x] pkgconfig.generate supports internal dependencies in requires
# 1.10.0
[source](https://mesonbuild.com/Release-notes-for-1-10-0.html)
- [x] Support for the counted_by attribute
- [x] Added a values() method for dictionaries
- [x] Add cmd_array method to ExternalProgram
- [x] Added OS/2 support (shortname kwarg / os2_emxomf builtin opt) *stub*
- [x] Array .slice() method
- [x] -Db_vscrt on clang
- [x] Added build_subdir arg to various targets
  - [x] configure_file
  - [x] build_target
  - [x] custom_target 
- [x] Methods from compiler object now accept strings for include_directories (already supported)
- [x] Using meson.get_compiler() to get a language from another project is marked (already an error)
- [x] Add a configure log in meson-logs (already supported)
- [x] Added new namingscheme option
- [x] New method to handle GNU and Windows symbol visibility for C/C++/ObjC/ObjC++
# 1.11.0
[source](https://mesonbuild.com/Release-notes-for-1-11-0.html)
- [x] BuildTarget(install_dir) length > 1 replaced with keywords
- [x] Deprecate should_fail and rename it to expected_fail, also introduce expected_exitcode
- [x] install_man and install_headers: add support for install_tag kwarg
- [x] Added link_early_args to targets performing linking
- [x] Machine files now expand ~ as the user's home directory
- [x] windows.compile_resources now detects header changes with rc.exe
- [x] Added implicit_include_directories argument to windows.compile_resources
- [x] Console kwarg on run_command

---

- [x] Fix newly failing and new failing tests
- [x] Update meson-docs repo
