### PR TITLE
Fixes for some fgets/fread reads flagged by -Wunused-result

### DIFF
--- a/src/external/readline_bestline.c
+++ b/src/external/readline_bestline.c
@@ -16,6 +16,9 @@ muon_readline(const char *prompt)
 {
 	static char buf[2048];
 	char *line = bestlineWithHistory(prompt, 0);
+	if (!line) {
+		return NULL;
+	}
 	uint32_t line_len = strlen(line);
 	line_len = line_len > sizeof(buf) - 1 ? sizeof(buf) - 1 : line_len;
 	memcpy(buf, line, line_len);

--- a/src/external/readline_builtin.c
+++ b/src/external/readline_builtin.c
@@ -15,21 +15,17 @@ char *
 muon_readline(const char *prompt)
 {
 	static char buf[2048];
-	if (feof(stdin)) {
+
+	log_raw("%s\n", prompt);
+	if (!fgets(buf, 2048, stdin)) {
 		return NULL;
 	}
 
-	log_raw("%s\n", prompt);
-	fgets(buf, 2048, stdin);
-
-	uint32_t len = strlen(buf);
-	int32_t i;
-	for (i = len - 1; i >= 0; --i) {
-		if (!strchr(" \n", buf[i])) {
-			break;
-		}
+	size_t len = strlen(buf);
+	while (len && strchr(" \n", buf[len - 1])) {
+		--len;
 	}
-	buf[i + 1] = 0;
+	buf[len] = 0;
 
 	return buf;
 }

--- a/src/platform/run_cmd.c
+++ b/src/platform/run_cmd.c
@@ -121,12 +121,21 @@ run_cmd_determine_interpreter_from_file(struct workspace *wk,
 		return false;
 	}
 
-	fread(buf, 1, buf_size - 1, f);
+	size_t bytes_read = fread(buf, 1, buf_size - 1, f);
+	bool read_failed = ferror(f);
+	bool close_failed = !fs_fclose(f);
 
-	if (!fs_fclose(f)) {
+	if (read_failed) {
+		*err_msg = "error determining command interpreter: failed to read file";
+		return false;
+	}
+
+	if (close_failed) {
 		*err_msg = "error determining command interpreter: failed to close file";
 		return false;
 	}
+
+	buf[bytes_read] = 0;
 
 	if (strncmp(buf, "#!", 2) != 0) {
 		*err_msg = "error determining command interpreter: missing #!";


### PR DESCRIPTION
a. readline_builtin.c: fgets can fail on the very first EOF and we'd replay the stale static buffer....the feof guard sort of didn't cover that case
b. readline_bestline.c: same end-of-input contract... strlen on bestline's NULL return could be a latent Ctrl-D crash
c. trailing trim: this is nit. mostly how unsigned signed mixed it was written...moved to size_t
d. run_cmd.c: This here has the motivation primarily for the warning: the buffer's already zeroed so nothing was truly broken. since fread's result has to be used, I spent it on a ferror() check.


I was checking open issues and I think this covers what is reported in #296 