### PR TITLE
lsp: don't leave req.root_path NULL when there is no project root

### DIFF
--- a/src/lang/lsp.c
+++ b/src/lang/lsp.c
@@ -1066,6 +1066,8 @@ analyze_server(struct workspace *srv_wk, struct az_opts *cmdline_opts)
 							goto analyze_done;
 						}
 						did_chdir = true;
+					} else {
+						srv->req.root_path = srv->req.path;
 					}
 				}
 			}

--- a/tests/lsp/meson.build
+++ b/tests/lsp/meson.build
@@ -6,6 +6,7 @@ lsp_tests = [
     ['diagnostics'],
     ['diagnostics_with_edit'],
     ['many edits'],
+    ['no_project_root'],
 ]
 
 foreach t : lsp_tests

--- a/tests/lsp/no_project_root/input.json
+++ b/tests/lsp/no_project_root/input.json
@@ -1,0 +1,12 @@
+[
+  {
+    "method": "textDocument/didOpen",
+    "params": {
+      "textDocument": {
+        "uri": "file:///muon-lsp-test-no-project-root/meson.build",
+        "languageId": "meson",
+        "text": "x = 1\n"
+      }
+    }
+  }
+]

--- a/tests/lsp/no_project_root/meson.build
+++ b/tests/lsp/no_project_root/meson.build
@@ -1,0 +1,3 @@
+project('no_project_root')
+
+unused_var = 1

--- a/tests/lsp/no_project_root/output.json
+++ b/tests/lsp/no_project_root/output.json
@@ -1,0 +1,24 @@
+[
+  {
+    "method": "muon/textDocument/publishDiagnostics",
+    "params": {
+      "relUri": "meson.build",
+      "diagnostics": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 0
+            },
+            "end": {
+              "line": 2,
+              "character": 10
+            }
+          },
+          "severity": 2,
+          "message": "unused variable unused_var"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Fixes the SIGSEGV in #301.

### The defect

`determine_project_root()` returns NULL for a `meson.build` with no `project()`
call anywhere up the tree. In `analyze_server()` its result is stored straight
into `srv->req.root_path`:

```c
if ((srv->req.root_path = determine_project_root(&wk, srv->req.path))) {
        ...chdir...
}
```

The failure is not otherwise handled, so control reaches
`az_srv_all_diagnostics()`, which uses `srv->req.root_path` unconditionally as
the key for the per-root list of diagnostics to clear:

```c
if ((val = hash_get_strn(&srv->diagnostics_map, srv->req.root_path, strlen(srv->req.root_path)))) {
```

That `strlen(NULL)` is the crash. Confirmed under gdb on a debug build of
3ee5438:

```
Program received signal SIGSEGV, Segmentation fault.
#1  az_srv_all_diagnostics (...) at ../src/lang/lsp.c:259
#2  analyze_server (...) at ../src/lang/lsp.c:1108
(gdb) p srv->req.root_path
$1 = 0x0
```

### The fix

Fall back to the requested file as the tracking key. The `.meson` branch
immediately above already stores a file path in `root_path`, so this follows
existing practice in the same function, and it keeps the behaviour that a
missing project root otherwise has: patching `root_path` to a valid string at
the crash site under gdb shows the analysis has already produced the useful
diagnostic, and it gets published as normal.

```
{"method": "textDocument/publishDiagnostics", "params": {"uri": "file://.../meson.build",
 "diagnostics": [{"range": ..., "severity": 1,
 "message": "first statement is not a call to project()"}]}}
```

An early return at the crash site would have suppressed that, which is why the
fix is at the assignment instead.

### Test

`tests/lsp/no_project_root` uses the existing runner: a `didOpen` for a file
whose path has no project root, against a fixture project that yields one
deterministic diagnostic, so a crash shows up as a missing message rather than
passing silently.

The opened path is a synthetic absolute path rather than a file in the fixture
directory on purpose — `determine_project_root()` walks up to the filesystem
root, so any path inside this repository resolves to muon's own `meson.build`
and cannot reproduce the NULL.

The expected `output.json` was not copied from the fixed build: it was derived
beforehand by setting `srv->req.root_path` to a valid pointer at `lsp.c:259`
under gdb and recording what the unfixed server then published.

### Verification

Before the change, on the unmodified tree:

```
$ muon -C build test -s lsp
....E
finished 5 tests, 0 expected fail, 1 fail, 0 skipped
fail   0.15s lsp:no_project_root
  stderr: caught signal 11 (segmentation fault)
  runner.meson:144:18: error in function 'run_command'
```

After:

```
$ muon -C build test -s lsp
.....
finished 5 tests, 0 expected fail, 0 fail, 0 skipped
```

Full suite: 416 tests, 392 ok, 20 skipped, 3 `failed_ok`, 1 failed —
`frameworks/7 gnome`, which fails identically on the unmodified tree here
because `gdbus-codegen` is not installed.

The reproducer from #301 also stops crashing: the server stays up and keeps
serving.

`clang-format --dry-run` reports the same set of pre-existing violations in
`src/lang/lsp.c` before and after, and `muon fmt -q` is clean on the changed
meson file.

### Not addressed here

While testing I hit a second, separate crash on the same handler path, still
present in this branch and not touched by it. `az_srv_set_request_path()`
assigns `path_str` unconditionally but `path` only on success:

```c
if ((srv->req.path_str = az_srv_uri_to_str(wk, _uri_s))) {
        srv->req.path = get_str(wk, srv->req.path_str)->s;
}
```

`az_srv_uri_to_str()` returns 0 for a URI whose scheme is not `file://`, and
for a `file://` URI whose percent-encoding does not decode. Neither caller
checks, so the pair is left inconsistent and there are two failure modes.

A bad URI on the first `didOpen`, with `path` still NULL — `az_srv_set_src_override()`
passes it straight to `analyze_opts_push_override()`:

```
#0  path_is_absolute (path=0x0) at ../src/platform/posix/path.c:16
#1  path_make_absolute (..., path=0x0) at ../src/platform/path.c:203
#2  analyze_opts_push_override (..., override=0x0, ...) at ../src/lang/analyze.c:1541
#3  az_srv_set_src_override (...) at ../src/lang/lsp.c:326
#4  az_srv_handle (...) at ../src/lang/lsp.c:448
```

A bad URI after a good one, so `path` holds the previous file while `path_str`
has been cleared to 0 — `analyze_server()` then does
`get_str(&wk, srv->req.path_str)`:

```
error internal type error, expected str but got null
caught signal 6 (abort)
```

Reproduced on the `edge` prebuilt `0.7.0-dev-3ee54382` with `untitled:Untitled-1`,
`vscode-notebook-cell:///x/meson.build` and `file:///a%zz/meson.build`. The LSP
spec puts no scheme restriction on `DocumentUri`, so a conformant client can
send any of these.

`didChange` and `didSave` reach the same helper, so they are affected too.

Left out to keep this change focused. Happy to open a separate issue, or fold a
fix in here if you would rather have both at once.
