### PR TITLE
Move per-language metadata into a script descriptor

### DIFF
--- a/include/toolchains.h
+++ b/include/toolchains.h
@@ -214,11 +214,6 @@ typedef bool ((*compiler_get_arg_func_1srb)(TOOLCHAIN_SIG_1srb));
 	_(needs_wipe, archiver, TOOLCHAIN_PARAMS_0rb)  \
 	_(version, archiver, TOOLCHAIN_PARAMS_0)
 
-struct language {
-	bool is_header;
-	bool is_linkable;
-};
-
 #undef TOOLCHAIN_ARG_MEMBER
 #undef TOOLCHAIN_ARG_MEMBER_
 
@@ -262,8 +257,6 @@ struct toolchain_registry {
 	struct language_descriptor descriptors[compiler_language_count];
 };
 
-extern const struct language languages[];
-
 struct compiler_check_cache_key {
 	struct obj_compiler *comp;
 	const char *argstr;
@@ -290,8 +283,10 @@ const char *compiler_language_to_s(enum compiler_language l);
 const char *compiler_language_to_gcc_name(enum compiler_language l);
 bool s_to_compiler_language(const char *s, enum compiler_language *l);
 
-bool filename_to_compiler_language(const char *str, enum compiler_language *l);
-const char *compiler_language_extension(enum compiler_language l);
+bool filename_to_compiler_language(struct workspace *wk, const char *str, enum compiler_language *l);
+const char *compiler_language_extension(struct workspace *wk, enum compiler_language l);
+bool compiler_language_is_header(enum compiler_language l);
+bool compiler_language_is_linkable(enum compiler_language l);
 enum compiler_language coalesce_link_languages(enum compiler_language cur, enum compiler_language new_lang);
 
 struct language_descriptor *language_descriptor_get(struct workspace *wk, enum compiler_language l);

--- a/include/toolchains.h
+++ b/include/toolchains.h
@@ -287,7 +287,7 @@ bool filename_to_compiler_language(struct workspace *wk, const char *str, enum c
 const char *compiler_language_extension(struct workspace *wk, enum compiler_language l);
 bool compiler_language_is_header(enum compiler_language l);
 bool compiler_language_is_linkable(enum compiler_language l);
-enum compiler_language coalesce_link_languages(enum compiler_language cur, enum compiler_language new_lang);
+enum compiler_language coalesce_link_languages(struct workspace *wk, enum compiler_language cur, enum compiler_language new_lang);
 
 struct language_descriptor *language_descriptor_get(struct workspace *wk, enum compiler_language l);
 

--- a/include/toolchains.h
+++ b/include/toolchains.h
@@ -245,9 +245,21 @@ struct toolchain_registry_component {
 	} sub_components[toolchain_component_count];
 };
 
+struct language_descriptor {
+	bool registered;
+	obj sources;              // dict: extension -> role ('compile' | 'header' | 'object')
+	obj std_option;           // option name (str), or 0
+	obj requires;             // array of OR-groups (array of array of language-name str)
+	obj env;                  // dict: knob name -> env var base name
+	enum compiler_language link_as;
+	uint32_t link_preference;
+	uint32_t archiver_preference;
+};
+
 struct toolchain_registry {
 	obj ids[toolchain_component_count];
 	struct arr components[toolchain_component_count];
+	struct language_descriptor descriptors[compiler_language_count];
 };
 
 extern const struct language languages[];
@@ -281,6 +293,8 @@ bool s_to_compiler_language(const char *s, enum compiler_language *l);
 bool filename_to_compiler_language(const char *str, enum compiler_language *l);
 const char *compiler_language_extension(enum compiler_language l);
 enum compiler_language coalesce_link_languages(enum compiler_language cur, enum compiler_language new_lang);
+
+struct language_descriptor *language_descriptor_get(struct workspace *wk, enum compiler_language l);
 
 bool
 toolchain_register_component(struct workspace *wk,

--- a/src/backend/common_args.c
+++ b/src/backend/common_args.c
@@ -178,13 +178,11 @@ ca_get_std_args(struct workspace *wk,
 {
 	obj std;
 
-	switch (get_obj_compiler(wk, comp)->lang) {
-	case compiler_language_objc:
-	case compiler_language_c: ca_get_option_value_for_tgt(wk, proj, tgt, "c_std", &std); break;
-	case compiler_language_objcpp:
-	case compiler_language_cpp: ca_get_option_value_for_tgt(wk, proj, tgt, "cpp_std", &std); break;
-	default: return;
+	struct language_descriptor *d = language_descriptor_get(wk, get_obj_compiler(wk, comp)->lang);
+	if (!d->std_option) {
+		return;
 	}
+	ca_get_option_value_for_tgt(wk, proj, tgt, get_cstr(wk, d->std_option), &std);
 
 	const char *s, *next = get_cstr(wk, std);
 	char buf[256];

--- a/src/backend/introspect.c
+++ b/src/backend/introspect.c
@@ -119,7 +119,7 @@ introspect_build_target(struct workspace *wk, struct project *proj, obj tgt)
 			obj_array_for(wk, t->src, file) {
 				const char *path = get_file_path(wk, file);
 				enum compiler_language file_lang;
-				if (!filename_to_compiler_language(path, &file_lang)) {
+				if (!filename_to_compiler_language(wk, path, &file_lang)) {
 					UNREACHABLE;
 				}
 

--- a/src/backend/ninja/build_target.c
+++ b/src/backend/ninja/build_target.c
@@ -342,7 +342,7 @@ ninja_write_build_tgt(struct workspace *wk, obj tgt_id, struct write_tgt_ctx *wc
 
 		obj_array_for(wk, tgt->src, v) {
 			enum compiler_language lang;
-			if (!filename_to_compiler_language(get_file_path(wk, v), &lang)) {
+			if (!filename_to_compiler_language(wk, get_file_path(wk, v), &lang)) {
 				UNREACHABLE;
 			}
 

--- a/src/backend/ninja/clang_format.c
+++ b/src/backend/ninja/clang_format.c
@@ -145,7 +145,7 @@ clang_format_collect_source_files_from_list(struct workspace *wk, struct clang_f
 		const struct str *path = get_str(wk, *get_obj_file(wk, file));
 
 		enum compiler_language l;
-		if (!(filename_to_compiler_language(path->s, &l))) {
+		if (!(filename_to_compiler_language(wk, path->s, &l))) {
 			continue;
 		}
 

--- a/src/backend/ninja/rules.c
+++ b/src/backend/ninja/rules.c
@@ -105,19 +105,14 @@ write_linker_rule(struct workspace *wk,
 static void
 write_archiver_rule(struct workspace *wk, FILE *out, struct project *proj, enum machine_kind machine)
 {
-	enum compiler_language archiver_precedence[] = {
-		compiler_language_c,
-		compiler_language_cpp,
-		compiler_language_objc,
-		compiler_language_objcpp,
-		compiler_language_nasm,
-	};
-
 	obj comp_id = 0;
-	uint32_t j;
-	for (j = 0; j < ARRAY_LEN(archiver_precedence); ++j) {
-		if (obj_dict_geti(wk, proj->toolchains[machine], archiver_precedence[j], &comp_id)) {
-			break;
+	uint32_t best_preference = 0;
+	for (enum compiler_language lang = 0; lang < compiler_language_count; ++lang) {
+		uint32_t preference = language_descriptor_get(wk, lang)->archiver_preference;
+		obj c;
+		if (preference > best_preference && obj_dict_geti(wk, proj->toolchains[machine], lang, &c)) {
+			best_preference = preference;
+			comp_id = c;
 		}
 	}
 

--- a/src/backend/xcode.c
+++ b/src/backend/xcode.c
@@ -253,7 +253,7 @@ xc_file(struct xc_ctx *ctx, const char *name, const char *path)
 
 	obj file_type;
 	enum compiler_language lang;
-	if (filename_to_compiler_language(path, &lang)) {
+	if (filename_to_compiler_language(ctx->wk, path, &lang)) {
 		file_type = make_strf(
 			ctx->wk, "sourcecode.%s.%s", compiler_language_to_s(lang), compiler_language_to_s(lang));
 	} else {

--- a/src/functions/build_target.c
+++ b/src/functions/build_target.c
@@ -211,7 +211,7 @@ build_target_extract_object(struct workspace *wk, struct build_target_extract_ob
 	}
 
 	enum compiler_language l;
-	if (!filename_to_compiler_language(get_file_path(wk, file), &l)) {
+	if (!filename_to_compiler_language(wk, get_file_path(wk, file), &l)) {
 		return false;
 	}
 

--- a/src/functions/compiler.c
+++ b/src/functions/compiler.c
@@ -163,7 +163,7 @@ compiler_check(struct workspace *wk, struct compiler_check_opts *opts, const cha
 	} else {
 		TSTR(test_source_path);
 		path_join(wk, &test_source_path, wk->muon_private, "test.");
-		tstr_pushs(wk, &test_source_path, compiler_language_extension(compiler->lang));
+		tstr_pushs(wk, &test_source_path, compiler_language_extension(wk, compiler->lang));
 		source_path = tstr_into_str(wk, &test_source_path);
 	}
 
@@ -188,7 +188,7 @@ compiler_check(struct workspace *wk, struct compiler_check_opts *opts, const cha
 			output_path = test_output_path.buf;
 		} else {
 			path_join(wk, &test_output_path, wk->muon_private, "test.");
-			tstr_pushs(wk, &test_output_path, compiler_language_extension(compiler->lang));
+			tstr_pushs(wk, &test_output_path, compiler_language_extension(wk, compiler->lang));
 			const char *ext
 				= toolchain_compiler_flatten_one(wk, comp, toolchain_compiler_object_ext(wk, comp));
 			if (!ext) {

--- a/src/functions/generator.c
+++ b/src/functions/generator.c
@@ -84,8 +84,8 @@ generated_list_process_file(struct workspace *wk,
 				const char *generated_path = get_cstr(wk, *get_obj_file(wk, file));
 
 				enum compiler_language l;
-				if (!*generated_include && filename_to_compiler_language(generated_path, &l)
-					&& languages[l].is_header) {
+				if (!*generated_include && filename_to_compiler_language(wk, generated_path, &l)
+					&& compiler_language_is_header(l)) {
 					*generated_include = true;
 				}
 

--- a/src/functions/kernel.c
+++ b/src/functions/kernel.c
@@ -120,33 +120,39 @@ project_add_language(struct workspace *wk,
 		}
 	}
 
-	switch (l) {
-	case compiler_language_assembly:
-	case compiler_language_nasm:
-	case compiler_language_objc:
-	case compiler_language_vala: {
-		obj c_compiler;
-		if (!obj_dict_geti(wk, current_project(wk)->toolchains[machine], compiler_language_c, &c_compiler)
-			&& !obj_dict_geti(
-				wk, current_project(wk)->toolchains[machine], compiler_language_cpp, &c_compiler)) {
-			bool c_found;
-			if (!project_add_language(wk, err_node, make_str(wk, "c"), compiler, machine, req, 0, &c_found)) {
-				return false;
+	// `requires` is a list of OR-groups; if a group has no member present, add
+	// its first.
+	struct language_descriptor *language_desc = language_descriptor_get(wk, l);
+	if (language_desc->requires) {
+		obj group;
+		obj_array_for(wk, language_desc->requires, group) {
+			bool satisfied = false;
+			obj member;
+			obj_array_for(wk, group, member) {
+				enum compiler_language required_lang;
+				obj present;
+				if (s_to_compiler_language(get_cstr(wk, member), &required_lang)
+					&& obj_dict_geti(
+						wk, current_project(wk)->toolchains[machine], required_lang, &present)) {
+					satisfied = true;
+					break;
+				}
+			}
+
+			if (!satisfied) {
+				bool req_found;
+				if (!project_add_language(wk,
+					    err_node,
+					    obj_array_index(wk, group, 0),
+					    compiler,
+					    machine,
+					    req,
+					    0,
+					    &req_found)) {
+					return false;
+				}
 			}
 		}
-	} break;
-	case compiler_language_objcpp: {
-		obj cpp_compiler;
-		if (!obj_dict_geti(
-			    wk, current_project(wk)->toolchains[machine], compiler_language_cpp, &cpp_compiler)) {
-			bool cpp_found;
-			if (!project_add_language(
-				    wk, err_node, make_str(wk, "cpp"), compiler, machine, req, 0, &cpp_found)) {
-				return false;
-			}
-		}
-	} break;
-	default: break;
 	}
 
 	*found = true;

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -86,7 +86,7 @@ determine_linker_iter(struct workspace *wk, void *_ctx, obj val)
 
 	enum compiler_language fl;
 
-	if (!filename_to_compiler_language(get_file_path(wk, val), &fl)) {
+	if (!filename_to_compiler_language(wk, get_file_path(wk, val), &fl)) {
 		/* LOG_E("unable to determine language for '%s'", get_cstr(wk, src->dat.file)); */
 		return ir_cont;
 	}
@@ -123,7 +123,7 @@ determine_linker_from_objects_iter(struct workspace *wk, void *_ctx, obj val)
 		return ir_cont;
 	}
 
-	if (!filename_to_compiler_language(path.buf, &fl)) {
+	if (!filename_to_compiler_language(wk, path.buf, &fl)) {
 		/* LOG_E("unable to determine language for '%s'", get_cstr(wk, src->dat.file)); */
 		return ir_cont;
 	}
@@ -241,7 +241,7 @@ build_tgt_push_source_files_iter(struct workspace *wk, void *_ctx, obj val)
 	}
 
 	enum compiler_language lang;
-	if (!filename_to_compiler_language(get_file_path(wk, val), &lang) || languages[lang].is_header) {
+	if (!filename_to_compiler_language(wk, get_file_path(wk, val), &lang) || compiler_language_is_header(lang)) {
 		obj_array_push(wk, tgt->extra_files, val);
 
 		// process every file that is either a header, or isn't
@@ -250,7 +250,7 @@ build_tgt_push_source_files_iter(struct workspace *wk, void *_ctx, obj val)
 			return ir_err;
 		}
 		return ir_cont;
-	} else if (languages[lang].is_linkable) {
+	} else if (compiler_language_is_linkable(lang)) {
 		obj_array_push(wk, tgt->objects, val);
 		return ir_cont;
 	}

--- a/src/functions/kernel/build_target.c
+++ b/src/functions/kernel/build_target.c
@@ -91,7 +91,7 @@ determine_linker_iter(struct workspace *wk, void *_ctx, obj val)
 		return ir_cont;
 	}
 
-	tgt->dep_internal.link_language = coalesce_link_languages(tgt->dep_internal.link_language, fl);
+	tgt->dep_internal.link_language = coalesce_link_languages(wk, tgt->dep_internal.link_language, fl);
 
 	return ir_cont;
 }
@@ -128,7 +128,7 @@ determine_linker_from_objects_iter(struct workspace *wk, void *_ctx, obj val)
 		return ir_cont;
 	}
 
-	tgt->dep_internal.link_language = coalesce_link_languages(tgt->dep_internal.link_language, fl);
+	tgt->dep_internal.link_language = coalesce_link_languages(wk, tgt->dep_internal.link_language, fl);
 
 	return ir_cont;
 }

--- a/src/functions/kernel/dependency.c
+++ b/src/functions/kernel/dependency.c
@@ -1742,7 +1742,7 @@ build_dep_merge(struct workspace *wk,
 
 	build_dep_init(wk, dest);
 
-	dest->link_language = coalesce_link_languages(src->link_language, dest->link_language);
+	dest->link_language = coalesce_link_languages(wk, src->link_language, dest->link_language);
 
 	if (src->link_with) {
 		obj_array_extend(wk, dest->link_with, src->link_with);

--- a/src/functions/modules/toolchain.c
+++ b/src/functions/modules/toolchain.c
@@ -398,6 +398,66 @@ FUNC_IMPL(module_toolchain, register_archiver, tc_dict, .desc = "Register a new 
 	return func_modue_toolchain_register_component_common(wk, toolchain_component_archiver, res);
 }
 
+FUNC_IMPL(module_toolchain, register_language, tc_dict, .desc = "Register metadata for a language")
+{
+	struct args_norm an[] = { { tc_string, .desc = "The language name (must match a known language)" }, ARG_TYPE_NULL };
+	enum kwargs {
+		kw_sources,
+		kw_std_option,
+		kw_link_as,
+		kw_link_preference,
+		kw_archiver_preference,
+		kw_requires,
+		kw_env,
+	};
+	struct args_kw akw[] = {
+		[kw_sources] = { "sources", tc_dict, .desc = "A dict mapping source extension to role ('compile', 'header' or 'object')." },
+		[kw_std_option] = { "std_option", tc_string, .desc = "Name of the per-project option carrying this language's standard/edition." },
+		[kw_link_as] = { "link_as", tc_string, .desc = "The link language this language contributes.  Defaults to itself." },
+		[kw_link_preference] = { "link_preference", tc_number, .desc = "Higher wins when a target mixes link languages." },
+		[kw_archiver_preference] = { "archiver_preference", tc_number, .desc = "Higher wins when selecting a target's archiver." },
+		[kw_requires] = { "requires", tc_array, .desc = "A list of prerequisite groups; each group is satisfied by any of its members." },
+		[kw_env] = { "env", tc_dict, .desc = "A dict of env-var override knobs, e.g. {'compiler': 'CC'}." },
+		0,
+	};
+	if (!pop_args(wk, an, akw)) {
+		return false;
+	}
+
+	if (wk->vm.in_analyzer) {
+		*res = make_typeinfo(wk, tc_dict);
+		return true;
+	}
+
+	enum compiler_language l;
+	if (!s_to_compiler_language(get_cstr(wk, an[0].val), &l)) {
+		vm_error_at(wk, an[0].node, "unknown language %o", an[0].val);
+		return false;
+	}
+
+	struct language_descriptor *d = language_descriptor_get(wk, l);
+	d->registered = true;
+	d->sources = akw[kw_sources].set ? akw[kw_sources].val : 0;
+	d->std_option = akw[kw_std_option].set ? akw[kw_std_option].val : 0;
+	d->requires = akw[kw_requires].set ? akw[kw_requires].val : 0;
+	d->env = akw[kw_env].set ? akw[kw_env].val : 0;
+	d->link_preference = akw[kw_link_preference].set ? get_obj_number(wk, akw[kw_link_preference].val) : 0;
+	d->archiver_preference = akw[kw_archiver_preference].set ? get_obj_number(wk, akw[kw_archiver_preference].val) : 0;
+
+	d->link_as = l;
+	if (akw[kw_link_as].set) {
+		enum compiler_language link_as;
+		if (!s_to_compiler_language(get_cstr(wk, akw[kw_link_as].val), &link_as)) {
+			vm_error_at(wk, akw[kw_link_as].node, "unknown link_as language %o", akw[kw_link_as].val);
+			return false;
+		}
+		d->link_as = link_as;
+	}
+
+	*res = make_obj(wk, obj_dict);
+	return true;
+}
+
 FUNC_IMPL(module_toolchain, handler, tc_closure | tc_array, func_impl_flag_impure, .desc = "Retrieve a previously defined handler")
 {
 	struct args_norm an[] = {
@@ -441,6 +501,7 @@ FUNC_REGISTER(module_toolchain)
 		FUNC_IMPL_REGISTER(module_toolchain, register_compiler);
 		FUNC_IMPL_REGISTER(module_toolchain, register_linker);
 		FUNC_IMPL_REGISTER(module_toolchain, register_archiver);
+		FUNC_IMPL_REGISTER(module_toolchain, register_language);
 		FUNC_IMPL_REGISTER(module_toolchain, handler);
 	}
 }

--- a/src/options.c
+++ b/src/options.c
@@ -782,19 +782,33 @@ option_env_var_mapping_for_machine(const char *env_var,
 	};
 }
 
+static const char *
+descriptor_env_var(struct workspace *wk, obj env, const char *key)
+{
+	obj name;
+	if (env && obj_dict_index_str(wk, env, key, &name)) {
+		return get_cstr(wk, name);
+	}
+	return 0;
+}
+
 static bool
 toolchain_component_option_info(struct workspace *wk, enum compiler_language l, enum toolchain_component c, enum machine_kind machine, struct option_env_var_mapping *mapping)
 {
-	const char *option_names[compiler_language_count][toolchain_component_count] = {
-		[compiler_language_c] = { "CC", "CC_LD", "AR" },
-		[compiler_language_cpp] = { "CXX", "CXX_LD", "AR" },
-		[compiler_language_objc] = { "OBJC", "OBJC_LD", "AR" },
-		[compiler_language_objcpp] = { "OBJCXX", "OBJCXX_LD", "AR" },
-		[compiler_language_nasm] = { "NASM", "NASM_LD", "AR" },
-		[compiler_language_vala] = { "VALAC", "VALAC_LD", "AR" },
-	};
+	obj env = wk->toolchain_registry.descriptors[l].env;
 
-	const char *n = option_names[l][c];
+	const char *n = 0;
+	switch (c) {
+	case toolchain_component_compiler: n = descriptor_env_var(wk, env, "compiler"); break;
+	case toolchain_component_linker: n = descriptor_env_var(wk, env, "linker"); break;
+	case toolchain_component_archiver:
+		// The archiver knob (AR) is shared across languages, but only offered
+		// by languages that carry env knobs at all.
+		n = env ? "AR" : 0;
+		break;
+	default: break;
+	}
+
 	if (!n) {
 		return false;
 	}
@@ -883,29 +897,21 @@ init_dynamic_compiler_options(struct workspace *wk, bool is_first)
 #undef TOOLCHAIN_ENUM
 	};
 
-	static const struct compile_opt_env_var {
-		const char *compile_flags;
-		const char *link_flags;
-		const char *preprocess_flags;
-	} compile_opt_env_var[compiler_language_count] = {
-		[compiler_language_c] = { "CFLAGS", "LDFLAGS", "CPPFLAGS" },
-		[compiler_language_cpp] = { "CXXFLAGS", "LDFLAGS", "CPPFLAGS" },
-		[compiler_language_objc] = { "OBJCFLAGS", "LDFLAGS", "CPPFLAGS" },
-		[compiler_language_objcpp] = { "OBJCXXFLAGS", "LDFLAGS", "CPPFLAGS" },
-	};
-
 	uint32_t i, machine;
 	for (i = 0; i < ARRAY_LEN(langs); ++i) {
 		for (machine = machine_kind_build; machine <= machine_kind_host; ++machine) {
 			const char *option_prefix = machine == machine_kind_build ? option_group_build : "";
-			const struct compile_opt_env_var *ev = &compile_opt_env_var[langs[i].l];
+			obj env = wk->toolchain_registry.descriptors[langs[i].l].env;
+			const char *compile_flags = descriptor_env_var(wk, env, "compile_flags");
+			const char *link_flags = descriptor_env_var(wk, env, "link_flags");
+			const char *preprocess_flags = descriptor_env_var(wk, env, "preprocess_flags");
 
 			struct {
 				obj option;
 				const char *env_var[2];
 			} custom_env_options[] = {
-				{ make_strf(wk, "%s%s_args", option_prefix, langs[i].name), { ev->compile_flags, ev->preprocess_flags } },
-				{ make_strf(wk, "%s%s_link_args", option_prefix, langs[i].name), { ev->link_flags, ev->preprocess_flags } },
+				{ make_strf(wk, "%s%s_args", option_prefix, langs[i].name), { compile_flags, preprocess_flags } },
+				{ make_strf(wk, "%s%s_link_args", option_prefix, langs[i].name), { link_flags, preprocess_flags } },
 			};
 
 			for (uint32_t o = 0; o < ARRAY_LEN(custom_env_options); ++o) {

--- a/src/script/runtime/toolchains.meson
+++ b/src/script/runtime/toolchains.meson
@@ -1113,3 +1113,130 @@ toolchain.register_compiler(
         'linker_passthrough': toolchain.handler('compiler', 'posix', 'linker_passthrough'),
     },
 )
+
+################################################################################
+# languages
+################################################################################
+#
+# Per-language metadata — everything about a language that isn't a compiler flag:
+# source extensions and their role, link-language selection, prerequisites, and
+# the names of its env override knobs.
+
+toolchain.register_language(
+    'c',
+    sources: {'c': 'compile', 'h': 'header', 'o': 'object', 'obj': 'object'},
+    std_option: 'c_std',
+    link_as: 'c',
+    link_preference: 20,
+    archiver_preference: 50,
+    env: {
+        'compiler': 'CC',
+        'linker': 'CC_LD',
+        'compile_flags': 'CFLAGS',
+        'link_flags': 'LDFLAGS',
+        'preprocess_flags': 'CPPFLAGS',
+    },
+)
+
+toolchain.register_language(
+    'cpp',
+    sources: {
+        'cc': 'compile',
+        'cpp': 'compile',
+        'cxx': 'compile',
+        'C': 'compile',
+        'hh': 'header',
+        'hpp': 'header',
+        'hxx': 'header',
+    },
+    std_option: 'cpp_std',
+    link_as: 'cpp',
+    link_preference: 30,
+    archiver_preference: 40,
+    env: {
+        'compiler': 'CXX',
+        'linker': 'CXX_LD',
+        'compile_flags': 'CXXFLAGS',
+        'link_flags': 'LDFLAGS',
+        'preprocess_flags': 'CPPFLAGS',
+    },
+)
+
+toolchain.register_language(
+    'objc',
+    sources: {'m': 'compile', 'M': 'compile'},
+    std_option: 'c_std',
+    link_as: 'c',
+    link_preference: 20,
+    archiver_preference: 30,
+    requires: [['c', 'cpp']],
+    env: {
+        'compiler': 'OBJC',
+        'linker': 'OBJC_LD',
+        'compile_flags': 'OBJCFLAGS',
+        'link_flags': 'LDFLAGS',
+        'preprocess_flags': 'CPPFLAGS',
+    },
+)
+
+toolchain.register_language(
+    'objcpp',
+    sources: {'mm': 'compile'},
+    std_option: 'cpp_std',
+    link_as: 'cpp',
+    link_preference: 30,
+    archiver_preference: 20,
+    requires: [['cpp']],
+    env: {
+        'compiler': 'OBJCXX',
+        'linker': 'OBJCXX_LD',
+        'compile_flags': 'OBJCXXFLAGS',
+        'link_flags': 'LDFLAGS',
+        'preprocess_flags': 'CPPFLAGS',
+    },
+)
+
+toolchain.register_language(
+    'assembly',
+    sources: {'S': 'compile', 's': 'compile'},
+    link_as: 'assembly',
+    link_preference: 10,
+    requires: [['c', 'cpp']],
+)
+
+toolchain.register_language(
+    'nasm',
+    sources: {'asm': 'compile'},
+    link_as: 'c',
+    link_preference: 20,
+    archiver_preference: 10,
+    requires: [['c', 'cpp']],
+    env: {'compiler': 'NASM', 'linker': 'NASM_LD'},
+)
+
+toolchain.register_language(
+    'masm',
+    link_as: 'c',
+    link_preference: 20,
+)
+
+toolchain.register_language(
+    'llvm_ir',
+    sources: {'ll': 'compile'},
+)
+
+toolchain.register_language(
+    'rust',
+    std_option: 'rust_std',
+    link_as: 'rust',
+    link_preference: 40,
+)
+
+toolchain.register_language(
+    'vala',
+    sources: {'vala': 'compile', 'vapi': 'compile'},
+    link_as: 'c',
+    link_preference: 20,
+    requires: [['c', 'cpp']],
+    env: {'compiler': 'VALAC', 'linker': 'VALAC_LD'},
+)

--- a/src/toolchains.c
+++ b/src/toolchains.c
@@ -240,24 +240,21 @@ compiler_language_to_hdr(enum compiler_language lang)
 	}
 }
 
-static const char *compiler_language_exts[compiler_language_count][10] = {
-	[compiler_language_c] = { "c" },
-	[compiler_language_c_hdr] = { "h" },
-	[compiler_language_cpp] = { "cc", "cpp", "cxx", "C" },
-	[compiler_language_cpp_hdr] = { "hh", "hpp", "hxx" },
-	[compiler_language_c_obj] = { "o", "obj" },
-	[compiler_language_objc] = { "m", "M" },
-	[compiler_language_objcpp] = { "mm" },
-	[compiler_language_assembly] = { "S", "s" },
-	[compiler_language_llvm_ir] = { "ll" },
-	[compiler_language_nasm] = { "asm" },
-	[compiler_language_vala] = { "vala", "vapi" },
-};
+static enum compiler_language
+language_role_to_enum(struct workspace *wk, enum compiler_language lang, obj role)
+{
+	const char *r = get_cstr(wk, role);
+	if (strcmp(r, "header") == 0) {
+		return compiler_language_to_hdr(lang);
+	} else if (strcmp(r, "object") == 0) {
+		return compiler_language_c_obj;
+	}
+	return lang;
+}
 
 bool
-filename_to_compiler_language(const char *str, enum compiler_language *l)
+filename_to_compiler_language(struct workspace *wk, const char *str, enum compiler_language *l)
 {
-	uint32_t i, j;
 	const char *ext;
 
 	if (!(ext = strrchr(str, '.'))) {
@@ -265,12 +262,12 @@ filename_to_compiler_language(const char *str, enum compiler_language *l)
 	}
 	++ext;
 
-	for (i = 0; i < compiler_language_count; ++i) {
-		for (j = 0; compiler_language_exts[i][j]; ++j) {
-			if (strcmp(ext, compiler_language_exts[i][j]) == 0) {
-				*l = i;
-				return true;
-			}
+	for (enum compiler_language lang = 0; lang < compiler_language_count; ++lang) {
+		obj sources = wk->toolchain_registry.descriptors[lang].sources;
+		obj role;
+		if (sources && obj_dict_index_str(wk, sources, ext, &role)) {
+			*l = language_role_to_enum(wk, lang, role);
+			return true;
 		}
 	}
 
@@ -278,9 +275,19 @@ filename_to_compiler_language(const char *str, enum compiler_language *l)
 }
 
 const char *
-compiler_language_extension(enum compiler_language l)
+compiler_language_extension(struct workspace *wk, enum compiler_language l)
 {
-	return compiler_language_exts[l][0];
+	obj sources = wk->toolchain_registry.descriptors[l].sources;
+	if (sources) {
+		obj ext, role;
+		obj_dict_for(wk, sources, ext, role) {
+			if (strcmp(get_cstr(wk, role), "compile") == 0) {
+				return get_cstr(wk, ext);
+			}
+		}
+	}
+
+	return 0;
 }
 
 // The link language a source language contributes.  Several source languages
@@ -1051,16 +1058,21 @@ TOOLCHAIN_PROTO_1srb(toolchain_arg_empty_1srb)
 	return false;
 }
 
-const struct language languages[compiler_language_count] = {
-	[compiler_language_null] = { 0 },
-	[compiler_language_c] = { .is_header = false },
-	[compiler_language_c_hdr] = { .is_header = true },
-	[compiler_language_cpp] = { .is_header = false },
-	[compiler_language_cpp_hdr] = { .is_header = true },
-	[compiler_language_c_obj] = { .is_linkable = true },
-	[compiler_language_assembly] = { 0 },
-	[compiler_language_llvm_ir] = { 0 },
-};
+bool
+compiler_language_is_header(enum compiler_language l)
+{
+	switch (l) {
+	case compiler_language_c_hdr:
+	case compiler_language_cpp_hdr: return true;
+	default: return false;
+	}
+}
+
+bool
+compiler_language_is_linkable(enum compiler_language l)
+{
+	return l == compiler_language_c_obj;
+}
 
 bool
 toolchain_register_component(struct workspace *wk,

--- a/src/toolchains.c
+++ b/src/toolchains.c
@@ -290,47 +290,32 @@ compiler_language_extension(struct workspace *wk, enum compiler_language l)
 	return 0;
 }
 
-// The link language a source language contributes.  Several source languages
-// compile with their own program but link through the C driver (objc, nasm,
-// masm, vala), and already-built objects link as C too.
+// The link language a source language contributes.  An already-built object
+// links as C; other pseudo-roles and unregistered languages contribute nothing.
 static enum compiler_language
-link_language_normalize(enum compiler_language lang)
+link_language_normalize(struct workspace *wk, enum compiler_language lang)
 {
-	switch (lang) {
-	case compiler_language_c:
-	case compiler_language_c_obj:
-	case compiler_language_objc:
-	case compiler_language_nasm:
-	case compiler_language_masm:
-	case compiler_language_vala: return compiler_language_c;
-	case compiler_language_cpp:
-	case compiler_language_objcpp: return compiler_language_cpp;
-	case compiler_language_assembly: return compiler_language_assembly;
-	case compiler_language_rust: return compiler_language_rust;
-	default: return compiler_language_null;
+	if (lang == compiler_language_c_obj) {
+		return compiler_language_c;
 	}
+	struct language_descriptor *d = &wk->toolchain_registry.descriptors[lang];
+	return d->registered ? d->link_as : compiler_language_null;
 }
 
 static uint32_t
-link_language_preference(enum compiler_language link_language)
+link_language_preference(struct workspace *wk, enum compiler_language link_language)
 {
-	switch (link_language) {
-	case compiler_language_rust: return 40;
-	case compiler_language_cpp: return 30;
-	case compiler_language_c: return 20;
-	case compiler_language_assembly: return 10;
-	default: return 0;
-	}
+	return wk->toolchain_registry.descriptors[link_language].link_preference;
 }
 
 enum compiler_language
-coalesce_link_languages(enum compiler_language cur, enum compiler_language new_lang)
+coalesce_link_languages(struct workspace *wk, enum compiler_language cur, enum compiler_language new_lang)
 {
 	// Order-independent: a target links as the highest-preference contributor
 	// among its sources.  Both operands are normalized because a merged
 	// dependency can arrive here as a raw (un-normalized) compiler language.
-	enum compiler_language a = link_language_normalize(cur), b = link_language_normalize(new_lang);
-	return link_language_preference(b) > link_language_preference(a) ? b : a;
+	enum compiler_language a = link_language_normalize(wk, cur), b = link_language_normalize(wk, new_lang);
+	return link_language_preference(wk, b) > link_language_preference(wk, a) ? b : a;
 }
 
 struct language_descriptor *

--- a/src/toolchains.c
+++ b/src/toolchains.c
@@ -326,6 +326,13 @@ coalesce_link_languages(enum compiler_language cur, enum compiler_language new_l
 	return link_language_preference(b) > link_language_preference(a) ? b : a;
 }
 
+struct language_descriptor *
+language_descriptor_get(struct workspace *wk, enum compiler_language l)
+{
+	assert(l < compiler_language_count);
+	return &wk->toolchain_registry.descriptors[l];
+}
+
 static bool
 run_cmd_arr(struct workspace *wk, struct run_cmd_ctx *cmd_ctx, obj cmd_arr, const char *arg)
 {
@@ -1653,6 +1660,8 @@ compiler_log_prefix(enum compiler_language lang, enum machine_kind machine)
 void
 compilers_init(struct workspace *wk)
 {
+	memset(wk->toolchain_registry.descriptors, 0, sizeof(wk->toolchain_registry.descriptors));
+
 	for (uint32_t i = 0; i < toolchain_component_count; ++i) {
 		arr_init(wk->a, &wk->toolchain_registry.components[i], 16, struct toolchain_registry_component);
 		toolchain_register_component(wk, i, &(struct toolchain_registry_component){ .id = { .id = "empty" } } );

--- a/src/toolchains.c
+++ b/src/toolchains.c
@@ -283,43 +283,47 @@ compiler_language_extension(enum compiler_language l)
 	return compiler_language_exts[l][0];
 }
 
-enum compiler_language
-coalesce_link_languages(enum compiler_language cur, enum compiler_language new)
+// The link language a source language contributes.  Several source languages
+// compile with their own program but link through the C driver (objc, nasm,
+// masm, vala), and already-built objects link as C too.
+static enum compiler_language
+link_language_normalize(enum compiler_language lang)
 {
-	switch (new) {
-	case compiler_language_null:
-	case compiler_language_c_hdr:
-	case compiler_language_cpp_hdr:
-	case compiler_language_objc_hdr:
-	case compiler_language_objcpp_hdr:
-	case compiler_language_llvm_ir: break;
-	case compiler_language_assembly:
-		if (!cur) {
-			return compiler_language_assembly;
-		}
-		break;
-	case compiler_language_nasm:
-	case compiler_language_masm:
+	switch (lang) {
 	case compiler_language_c:
 	case compiler_language_c_obj:
 	case compiler_language_objc:
-	case compiler_language_vala:
-		if (!cur) {
-			return compiler_language_c;
-		}
-		break;
+	case compiler_language_nasm:
+	case compiler_language_masm:
+	case compiler_language_vala: return compiler_language_c;
 	case compiler_language_cpp:
-	case compiler_language_objcpp:
-		if (!cur || cur == compiler_language_c || cur == compiler_language_assembly) {
-			return compiler_language_cpp;
-		}
-		break;
-	case compiler_language_rust:
-		return compiler_language_rust;
-	case compiler_language_count: UNREACHABLE;
+	case compiler_language_objcpp: return compiler_language_cpp;
+	case compiler_language_assembly: return compiler_language_assembly;
+	case compiler_language_rust: return compiler_language_rust;
+	default: return compiler_language_null;
 	}
+}
 
-	return cur;
+static uint32_t
+link_language_preference(enum compiler_language link_language)
+{
+	switch (link_language) {
+	case compiler_language_rust: return 40;
+	case compiler_language_cpp: return 30;
+	case compiler_language_c: return 20;
+	case compiler_language_assembly: return 10;
+	default: return 0;
+	}
+}
+
+enum compiler_language
+coalesce_link_languages(enum compiler_language cur, enum compiler_language new_lang)
+{
+	// Order-independent: a target links as the highest-preference contributor
+	// among its sources.  Both operands are normalized because a merged
+	// dependency can arrive here as a raw (un-normalized) compiler language.
+	enum compiler_language a = link_language_normalize(cur), b = link_language_normalize(new_lang);
+	return link_language_preference(b) > link_language_preference(a) ? b : a;
 }
 
 static bool

--- a/tests/project/meson.build
+++ b/tests/project/meson.build
@@ -13,6 +13,7 @@ tests = [
     ['muon/vala', {'vala': true}],
     ['muon/disabler', {}],
     ['muon/configure_file_cmake', {}],
+    ['muon/asm_link_language', {}],
 
     # project tests imported from meson unit tests
     # TODO: move this to meson-tests

--- a/tests/project/muon/asm_link_language/boot.S
+++ b/tests/project/muon/asm_link_language/boot.S
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: Stone Tickle <lattis@mochiro.moe> */
+/* SPDX-License-Identifier: GPL-3.0-only */
+/* Intentionally empty: its only job is to make the target contain an assembly
+ * source so link-language selection has to reconcile asm with C. */

--- a/tests/project/muon/asm_link_language/check_link.sh
+++ b/tests/project/muon/asm_link_language/check_link.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Stone Tickle <lattis@mochiro.moe>
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Asserts that both asm+c targets link through the C driver rule, independent of
+# source order. Runs with cwd = build root, so build.ninja is right here.
+
+set -eu
+
+ninja=build.ninja
+if [ ! -f "$ninja" ]; then
+	echo "check_link: $ninja not found in $(pwd)" >&2
+	exit 1
+fi
+
+rc=0
+for tgt in asmc casm; do
+	line=$(grep -E "^build ${tgt}:" "$ninja" || true)
+	if [ -z "$line" ]; then
+		echo "check_link: no build edge for '$tgt'" >&2
+		rc=1
+	elif echo "$line" | grep -q 'assembly_linker'; then
+		echo "check_link: FAIL '$tgt' links as assembly, expected C: $line" >&2
+		rc=1
+	elif echo "$line" | grep -q 'c_linker'; then
+		echo "check_link: OK '$tgt' links as C"
+	else
+		echo "check_link: FAIL '$tgt' unexpected link rule: $line" >&2
+		rc=1
+	fi
+done
+
+exit $rc

--- a/tests/project/muon/asm_link_language/main.c
+++ b/tests/project/muon/asm_link_language/main.c
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Stone Tickle <lattis@mochiro.moe>
+// SPDX-License-Identifier: GPL-3.0-only
+
+int
+main(void)
+{
+	return 0;
+}

--- a/tests/project/muon/asm_link_language/meson.build
+++ b/tests/project/muon/asm_link_language/meson.build
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Stone Tickle <lattis@mochiro.moe>
+# SPDX-License-Identifier: GPL-3.0-only
+
+project('asm-link', 'c')
+
+if host_machine.system() == 'windows'
+    error('MESON_SKIP_TEST: link-language check relies on a POSIX shell')
+endif
+
+# A target mixing assembly with C must link as C regardless of source order.
+# Before the order-independent link-selection fix, ['boot.S', 'main.c'] linked
+# as assembly while ['main.c', 'boot.S'] linked as C.
+executable('asmc', ['boot.S', 'main.c'])
+executable('casm', ['main.c', 'boot.S'])
+
+test('link-language-selection', find_program('check_link.sh'))


### PR DESCRIPTION
Groundwork for Rust support (#173). As pointed out in the issue itself, the blocker there was never really Rust — it's that language-specific facts are hardcoded for C in the core backend. muon already moved toolchain flags into script (toolchains.meson); this does the same for language metadata, which was still spread across a handful of C tables.

What's here in the PR: a toolchain.register_language that fills a per-language descriptor from script, with every in-tree language registered in toolchains.meson. The C readers now go through it: source extensions + roles, *_std, env knobs (CC/CFLAGS/…), language prerequisites, archiver precedence, link-language selection.... and their old hardcoded tables are removed.

One real behavior change, kept as the first commit:
link-language selection is now order-independent. It used to depend on source order ([asm, c] linked as assembly, [c, asm] as C) from precedence ladder..: now it's a preference argmax. More a de-quirk than a user-facing fix: assembly links through the C driver either way, so the emitted commands don't change.

PS: This is first of the PRs for the foundation sort of.